### PR TITLE
fix: when reusing a cloned repository we added an entropy suffix 

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -330,7 +330,7 @@ func cloneRepositoryOrGetFromCache(ctx context.Context, repo Repository, opts Op
 	}
 
 	exec := exec.NewExecer(reposDir, opts.Debug)
-	repoDir := cloneDir + "_" + time.Now().Format("_999999")
+	repoDir := cloneDir + "_" + time.Now().Format("05.999999999")
 
 	if _, err := exec.RunX(ctx, "cp", "-r", cloneDir, repoDir); err != nil {
 		_ = os.RemoveAll(repoDir)


### PR DESCRIPTION
which relied on microtime but it wasn't working properly always outputing `999999`.

replaces https://github.com/jcchavezs/gh-iterator/pull/10

cc @TarasHrynchuk