### PR TITLE
chore: improves caching by being aware of the cloning subset.

### DIFF
--- a/random.go
+++ b/random.go
@@ -1,0 +1,15 @@
+package iterator
+
+import (
+	"math/rand"
+)
+
+var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func randSequence(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}


### PR DESCRIPTION
It could happen we cache the same cloned folder although they have different cloning subsets which means the first cloning subset will be right and the other will be wrongly cached.