### PR TITLE
chore: adds support for 'head' option in PR creation.

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -134,6 +134,8 @@ type PROptions struct {
 	Body string
 	// Draft will open the PR as draft when true
 	Draft bool
+	// The branch that contains commits for your pull request
+	Head string
 }
 
 type pr struct {
@@ -196,6 +198,9 @@ func CreatePRIfNotExist(ctx context.Context, exec iteratorexec.Execer, opts PROp
 		}
 		if opts.Title != "" {
 			createPRArgs = append(createPRArgs, "--title", opts.Title)
+		}
+		if opts.Head != "" {
+			createPRArgs = append(createPRArgs, "--head", opts.Head)
 		}
 
 		if prBodyFile == "" || opts.Title == "" {


### PR DESCRIPTION
This pull request introduces a new `Head` field to the `PROptions` struct in `github/github.go` and updates the `CreatePRIfNotExist` function to support specifying the branch containing commits for a pull request. These changes enhance the flexibility of the pull request creation process.

### Enhancements to pull request creation:
* Added a `Head` field to the `PROptions` struct to specify the branch containing commits for a pull request. (`github/github.go`, [github/github.goR137-R138](diffhunk://#diff-9ba908d887f1d686a0a524b3cb3ff334b402122a9e5c4b8ba150a5fa6b5ff16bR137-R138))
* Updated the `CreatePRIfNotExist` function to include the `--head` argument when the `Head` field is provided, enabling users to specify the source branch for the pull request. (`github/github.go`, [github/github.goR202-R204](diffhunk://#diff-9ba908d887f1d686a0a524b3cb3ff334b402122a9e5c4b8ba150a5fa6b5ff16bR202-R204))