### PR TITLE
chore(breaking): rewrite the exec API to embrace testing.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 install-tools: ## Install tools
-	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.0.2
+	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0
 
 check-tool-%:
 	@which $* > /dev/null || (echo "Install $* with 'make install-tools'"; exit 1 )

--- a/examples/govulncheck/main.go
+++ b/examples/govulncheck/main.go
@@ -26,7 +26,7 @@ func main() {
 	defer f.Close() //nolint:errcheck
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
-		Level: slog.LevelDebug,
+		Level: slog.LevelInfo,
 	}))
 
 	res, err := iterator.RunForOrganization(context.Background(), org, iterator.SearchOptions{
@@ -42,11 +42,11 @@ func main() {
 			return fmt.Errorf("checking for vulnerabilities: %w", err)
 		}
 
-		if res.ExitCode() == 0 {
+		if res.ExitCode == 0 {
 			_, _ = fmt.Printf("No vulnerabilities found for %s/%s\n", org, repository)
 		} else if len(res.TrimStdout()) > 0 {
 			_, _ = fmt.Fprintf(f, "%s\n%s\n", repository, strings.Repeat("-", len(repository)))
-			_, _ = f.WriteString(res.Stdout())
+			_, _ = f.WriteString(res.Stdout)
 			_, _ = f.WriteString("\n")
 		}
 

--- a/examples/singlefile/main.go
+++ b/examples/singlefile/main.go
@@ -35,7 +35,7 @@ func main() {
 				return err
 			}
 
-			if res.ExitCode() == 0 {
+			if res.ExitCode == 0 {
 				fmt.Printf("- Repository %s/%s has %s\n", org, repository, readmeFile)
 				return nil
 			}

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -14,88 +14,96 @@ import (
 	"github.com/spf13/afero"
 )
 
-type Execer struct {
-	dir string
-	// Deprecated: use logger instead
-	printCommand bool
-	logger       *slog.Logger
-	env          []string
+type Execer interface {
+	Run(ctx context.Context, command string, args ...string) (Result, error)
+	RunX(ctx context.Context, command string, args ...string) (string, error)
+	RunWithStdin(ctx context.Context, stdin io.Reader, command string, args ...string) (Result, error)
+	RunWithStdinX(ctx context.Context, stdin io.Reader, command string, args ...string) (string, error)
+	Log(ctx context.Context, level slog.Level, msg string, fields ...any)
+	WithEnv(kv ...string) Execer
+	WithLogFields(fields ...any) Execer
+	Sub(subpath string) (Execer, error)
+	GenerateFS() afero.Fs
+}
+
+var _ Execer = execer{}
+
+type execer struct {
+	dir    string
+	logger *slog.Logger
+	env    []string
 }
 
 // NewExecer creates a new execer
 // printCommand is deprecated
-func NewExecer(dir string, printCommand bool) Execer {
-	return Execer{
-		dir:          dir,
-		printCommand: printCommand,
-		logger:       slog.New(log.DiscardHandler),
+func NewExecer(dir string) Execer {
+	return execer{
+		dir:    dir,
+		logger: slog.New(log.DiscardHandler),
 	}
 }
 
 // NewExecerWithLogger creates a new execer with a logger
 func NewExecerWithLogger(dir string, logger *slog.Logger) Execer {
-	return Execer{
+	return execer{
 		dir:    dir,
 		logger: logger,
 	}
 }
 
 // WithEnv creates a child execer with added env variables
-func WithEnv(e Execer, kv ...string) Execer {
-	var env []string
+func (e execer) WithEnv(kv ...string) Execer {
+	var env = e.env
 	kvLen := len(kv)
-	if kvLen == 0 {
+	if kvLen == 0 || kvLen == 1 {
 		return e
 	} else if kvLen%2 != 0 {
 		kv = kv[:kvLen-1]
 	}
 
-	for i := range kvLen % 2 {
-		env = append(env, fmt.Sprintf("%s=%s", kv[i], kv[i+1]))
+	for i := range kvLen / 2 {
+		env = append(env, fmt.Sprintf("%s=%s", kv[2*i], kv[2*i+1]))
 	}
 
-	return Execer{
-		dir:          e.dir,
-		printCommand: e.printCommand,
-		logger:       e.logger,
-		env:          env,
+	return execer{
+		dir:    e.dir,
+		logger: e.logger,
+		env:    env,
 	}
 }
 
-// WithLogArgs creates a child execer with added log args
-func WithLogArgs(e Execer, args ...any) Execer {
-	return Execer{
-		dir:          e.dir,
-		printCommand: e.printCommand,
-		logger:       e.logger.With(args...),
-		env:          e.env,
+// WithLogFields creates a child execer with added log fields
+func (e execer) WithLogFields(fields ...any) Execer {
+	return execer{
+		dir:    e.dir,
+		logger: e.logger.With(fields...),
+		env:    e.env,
 	}
 }
 
 // Sub creates a new execer in an existing subpath.
-func Sub(e Execer, subpath string) (Execer, error) {
+func (e execer) Sub(subpath string) (Execer, error) {
 	subdir := filepath.Join(e.dir, subpath)
 	if finfo, err := os.Stat(subdir); err != nil {
-		return Execer{}, err
+		return execer{}, err
 	} else if !finfo.IsDir() {
-		return Execer{}, fmt.Errorf("subpath %s is not a directory", subdir)
+		return execer{}, fmt.Errorf("subpath %s is not a directory", subdir)
 	}
 
-	return Execer{
-		dir:          subdir,
-		printCommand: e.printCommand,
-		logger:       e.logger,
-		env:          e.env,
+	return execer{
+		dir:    subdir,
+		logger: e.logger,
+		env:    e.env,
 	}, nil
 }
 
-// FS returns a FS object relative to the exec dir to interact with
-func FS(e Execer) afero.Fs {
+// GenerateFS returns a FS object relative to the exec dir to interact with
+func (e execer) GenerateFS() afero.Fs {
 	return afero.NewBasePathFs(afero.NewOsFs(), e.dir)
 }
 
 // Run executes a command with the repository's folder as working dir
-func (e Execer) Run(ctx context.Context, command string, args ...string) (Result, error) {
+func (e execer) Run(ctx context.Context, command string, args ...string) (Result, error) {
 	return e.RunWithStdin(ctx, nil, command, args...)
 }
 
@@ -107,30 +115,30 @@ func TrimStdout(o string, err error) (string, error) {
 
 // RunX executes a command with repository's folder as working dir. It will return an error
 // if exit code is non zero.
-func (e Execer) RunX(ctx context.Context, command string, args ...string) (string, error) {
+func (e execer) RunX(ctx context.Context, command string, args ...string) (string, error) {
 	res, err := e.Run(ctx, command, args...)
 	if err != nil {
 		return "", err
 	}
 
-	if res.ExitCode() != 0 {
-		return res.Stdout(), NewExecErr(
-			fmt.Sprintf("%s: exit code %d", cmdString(command, args...), res.ExitCode()),
-			res.Stderr(), res.ExitCode(),
+	if res.ExitCode != 0 {
+		return res.Stdout, NewExecErr(
+			fmt.Sprintf("%s: exit code %d", cmdString(command, args...), res.ExitCode),
+			res.Stderr, res.ExitCode,
 		)
 	}
 
-	return res.Stdout(), nil
+	return res.Stdout, nil
 }
 
 // Run executes a command with the repository's folder as working dir accepting a stdin
-func (e Execer) RunWithStdin(ctx context.Context, stdin io.Reader, command string, args ...string) (Result, error) {
+func (e execer) RunWithStdin(ctx context.Context, stdin io.Reader, command string, args ...string) (Result, error) {
 	task := execute.ExecTask{
-		Command:      command,
-		Args:         args,
-		Cwd:          e.dir,
-		PrintCommand: e.printCommand,
-		Stdin:        stdin,
+		Command: command,
+		Args:    args,
+		Cwd:     e.dir,
+		Stdin:   stdin,
+		Env:     e.env,
 	}
 
 	cmdS := cmdString(command, args...)
@@ -138,29 +146,29 @@ func (e Execer) RunWithStdin(ctx context.Context, stdin io.Reader, command strin
 
 	execRes, err := task.Execute(ctx)
 	if err != nil {
-		return result{}, fmt.Errorf("%s: %w", cmdS, err)
+		return Result{}, fmt.Errorf("%s: %w", cmdS, err)
 	}
 
-	return result{execRes}, nil
+	return Result(execRes), nil
 }
 
-func (e Execer) RunWithStdinX(ctx context.Context, stdin io.Reader, command string, args ...string) (string, error) {
+func (e execer) RunWithStdinX(ctx context.Context, stdin io.Reader, command string, args ...string) (string, error) {
 	res, err := e.RunWithStdin(ctx, stdin, command, args...)
 	if err != nil {
 		return "", err
 	}
 
-	if res.ExitCode() != 0 {
-		return res.Stdout(), NewExecErr(
-			fmt.Sprintf("%s: exit code %d", cmdString(command, args...), res.ExitCode()),
-			res.Stderr(), res.ExitCode(),
+	if res.ExitCode != 0 {
+		return res.Stdout, NewExecErr(
+			fmt.Sprintf("%s: exit code %d", cmdString(command, args...), res.ExitCode),
+			res.Stderr, res.ExitCode,
 		)
 	}
 
-	return res.Stdout(), nil
+	return res.Stdout, nil
 }
 
-func (e Execer) Log(ctx context.Context, level slog.Level, msg string, args ...any) {
+func (e execer) Log(ctx context.Context, level slog.Level, msg string, args ...any) {
 	e.logger.Log(ctx, level, msg, args...)
 }
 
@@ -169,35 +177,14 @@ func cmdString(command string, args ...string) string {
 }
 
 // Result holds the result from a command run
-type Result interface {
-	Stdout() string
-	TrimStdout() string
-	Stderr() string
-	ExitCode() int
-	Cancelled() bool
-}
-
-type result struct {
-	execute.ExecResult
-}
-
-func (r result) Stdout() string {
-	return r.ExecResult.Stdout
+type Result struct {
+	Stdout    string
+	Stderr    string
+	ExitCode  int
+	Cancelled bool
 }
 
 // TrimStdout returns the content of stdout removing the trailing new lines.
-func (r result) TrimStdout() string {
-	return strings.TrimSpace(r.ExecResult.Stdout)
-}
-
-func (r result) Stderr() string {
-	return r.ExecResult.Stderr
-}
-
-func (r result) ExitCode() int {
-	return r.ExecResult.ExitCode
-}
-
-func (r result) Cancelled() bool {
-	return r.ExecResult.Cancelled
+func (r Result) TrimStdout() string {
+	return strings.TrimSpace(r.Stdout)
 }

--- a/exec/exec_test.go
+++ b/exec/exec_test.go
@@ -2,7 +2,10 @@ package exec
 
 import (
 	"context"
+	"log/slog"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -11,11 +14,11 @@ import (
 
 func TestFS(t *testing.T) {
 	dir := t.TempDir()
-	e := NewExecer(dir, false)
+	e := NewExecer(dir)
 	_, err := e.RunX(context.Background(), "touch", "a.txt")
 	require.NoError(t, err)
 
-	fs := FS(e)
+	fs := e.GenerateFS()
 
 	t.Run("exists", func(t *testing.T) {
 		exists, err := afero.Exists(fs, "a.txt")
@@ -32,7 +35,7 @@ func TestFS(t *testing.T) {
 
 func TestTrimStdout(t *testing.T) {
 	dir := t.TempDir()
-	e := NewExecer(dir, false)
+	e := NewExecer(dir)
 	out, err := e.RunX(context.Background(), "echo", "Hello World")
 	require.NoError(t, err)
 	require.Equal(t, "Hello World\n", out)
@@ -44,14 +47,111 @@ func TestTrimStdout(t *testing.T) {
 
 func TestSub(t *testing.T) {
 	dir := t.TempDir()
-	e := NewExecer(dir, false)
-	_, err := Sub(e, "subdir")
+	e := NewExecer(dir)
+	_, err := e.Sub("subdir")
 	require.Error(t, err)
 
 	_, err = e.RunX(context.Background(), "mkdir", "subdir")
 	require.NoError(t, err)
 
-	se, err := Sub(e, "subdir")
+	se, err := e.Sub("subdir")
 	require.NoError(t, err)
-	require.Equal(t, filepath.Join(dir, "subdir"), se.dir)
+	require.Equal(t, filepath.Join(dir, "subdir"), se.(execer).dir)
+}
+
+func TestWithEnv(t *testing.T) {
+	dir := t.TempDir()
+	e := NewExecer(dir).(execer)
+
+	t.Run("no env vars", func(t *testing.T) {
+		childE := e.WithEnv().(execer)
+		require.Equal(t, e.env, childE.env)
+		require.Equal(t, e.dir, childE.dir)
+	})
+
+	t.Run("single env var pair", func(t *testing.T) {
+		childE := e.WithEnv("KEY1", "value1").(execer)
+		require.Equal(t, []string{"KEY1=value1"}, childE.env)
+		require.Equal(t, e.dir, childE.dir)
+	})
+
+	t.Run("multiple env var pairs", func(t *testing.T) {
+		childE := e.WithEnv("KEY1", "value1", "KEY2", "value2").(execer)
+		require.Equal(t, []string{"KEY1=value1", "KEY2=value2"}, childE.env)
+		require.Equal(t, e.dir, childE.dir)
+	})
+
+	t.Run("odd number of args", func(t *testing.T) {
+		childE := e.WithEnv("KEY1", "value1", "KEY2").(execer)
+		require.Equal(t, []string{"KEY1=value1"}, childE.env)
+	})
+
+	t.Run("with existing env vars", func(t *testing.T) {
+		parentE := e.WithEnv("CHILD", "value1").(execer)
+		childE := parentE.WithEnv("CHILD", "value2").(execer)
+		require.Equal(t, []string{"CHILD=value1", "CHILD=value2"}, childE.env)
+
+		res, err := childE.Run(context.Background(), os.Getenv("SHELL"), "-c", "echo \"$CHILD\"")
+		require.NoError(t, err)
+		require.Equal(t, "value2", res.TrimStdout())
+	})
+}
+
+func TestExecerLog(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("logs with different levels", func(t *testing.T) {
+		var logOutput strings.Builder
+		logger := slog.New(slog.NewTextHandler(&logOutput, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))
+
+		e := NewExecerWithLogger(dir, logger)
+		ctx := context.Background()
+
+		e.Log(ctx, slog.LevelDebug, "debug message")
+		e.Log(ctx, slog.LevelInfo, "info message")
+		e.Log(ctx, slog.LevelWarn, "warn message")
+		e.Log(ctx, slog.LevelError, "error message")
+
+		output := logOutput.String()
+		require.Contains(t, output, "info message")
+		require.Contains(t, output, "warn message")
+		require.Contains(t, output, "error message")
+	})
+
+	t.Run("logs with fields", func(t *testing.T) {
+		var logOutput strings.Builder
+		logger := slog.New(slog.NewTextHandler(&logOutput, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		}))
+
+		e := NewExecerWithLogger(dir, logger)
+		ctx := context.Background()
+
+		e.Log(ctx, slog.LevelInfo, "message with fields", "key1", "value1", "key2", "value2")
+
+		output := logOutput.String()
+		require.Contains(t, output, "message with fields")
+		require.Contains(t, output, "key1=value1")
+		require.Contains(t, output, "key2=value2")
+	})
+
+	t.Run("logs with execer created with log fields", func(t *testing.T) {
+		var logOutput strings.Builder
+		logger := slog.New(slog.NewTextHandler(&logOutput, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		}))
+
+		e := NewExecerWithLogger(dir, logger)
+		eWithFields := e.WithLogFields("persistent", "field")
+		ctx := context.Background()
+
+		eWithFields.Log(ctx, slog.LevelInfo, "test message", "additional", "field")
+
+		output := logOutput.String()
+		require.Contains(t, output, "test message")
+		require.Contains(t, output, "persistent=field")
+		require.Contains(t, output, "additional=field")
+	})
 }

--- a/exec/mock/mock.go
+++ b/exec/mock/mock.go
@@ -1,0 +1,61 @@
+package mock
+
+import (
+	"context"
+	"io"
+	"log/slog"
+
+	iteratorexec "github.com/jcchavezs/gh-iterator/exec"
+	"github.com/spf13/afero"
+)
+
+type Execer struct {
+	RunFn           func(ctx context.Context, command string, args ...string) (iteratorexec.Result, error)
+	RunXFn          func(ctx context.Context, command string, args ...string) (string, error)
+	RunWithStdinFn  func(ctx context.Context, stdin io.Reader, command string, args ...string) (iteratorexec.Result, error)
+	RunWithStdinXFn func(ctx context.Context, stdin io.Reader, command string, args ...string) (string, error)
+	Logger          *slog.Logger
+
+	WithEnvFn       func(kv ...string) iteratorexec.Execer
+	WithLogFieldsFn func(fields ...any) iteratorexec.Execer
+	SubFn           func(subpath string) (iteratorexec.Execer, error)
+	GenerateFSFn    func() afero.Fs
+}
+
+var _ iteratorexec.Execer = Execer{}
+
+func (x Execer) Run(ctx context.Context, command string, args ...string) (iteratorexec.Result, error) {
+	return x.RunFn(ctx, command, args...)
+}
+
+func (x Execer) RunX(ctx context.Context, command string, args ...string) (string, error) {
+	return x.RunXFn(ctx, command, args...)
+}
+
+func (x Execer) RunWithStdin(ctx context.Context, stdin io.Reader, command string, args ...string) (iteratorexec.Result, error) {
+	return x.RunWithStdinFn(ctx, stdin, command, args...)
+}
+
+func (x Execer) RunWithStdinX(ctx context.Context, stdin io.Reader, command string, args ...string) (string, error) {
+	return x.RunWithStdinXFn(ctx, stdin, command, args...)
+}
+
+func (x Execer) Log(ctx context.Context, level slog.Level, msg string, fields ...any) {
+	x.Logger.Log(ctx, level, msg, fields...)
+}
+
+func (x Execer) WithEnv(kv ...string) iteratorexec.Execer {
+	return x.WithEnvFn(kv...)
+}
+
+func (x Execer) WithLogFields(fields ...any) iteratorexec.Execer {
+	return x.WithLogFieldsFn(fields...)
+}
+
+func (x Execer) Sub(subpath string) (iteratorexec.Execer, error) {
+	return x.SubFn(subpath)
+}
+
+func (x Execer) GenerateFS() afero.Fs {
+	return x.GenerateFSFn()
+}

--- a/github/github.go
+++ b/github/github.go
@@ -171,7 +171,7 @@ func CreatePRIfNotExist(ctx context.Context, exec iteratorexec.Execer, opts PROp
 	)
 	if res, err := exec.Run(ctx, "gh", "pr", "view", "--json", "url,state,isDraft"); err != nil {
 		return "", false, fmt.Errorf("checking existing PR: %w", err)
-	} else if res.ExitCode() == 0 {
+	} else if res.ExitCode == 0 {
 		// PR exists
 		var pr struct {
 			URL     string `json:"url"`
@@ -179,7 +179,7 @@ func CreatePRIfNotExist(ctx context.Context, exec iteratorexec.Execer, opts PROp
 			IsDraft bool   `json:"isDraft"`
 		}
 
-		if err := json.NewDecoder(strings.NewReader(res.Stdout())).Decode(&pr); err != nil {
+		if err := json.NewDecoder(strings.NewReader(res.Stdout)).Decode(&pr); err != nil {
 			return "", false, fmt.Errorf("unmarshaling existing PR: %w", err)
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/jcchavezs/gh-iterator
 
-go 1.23.0
+go 1.24.0
+
+toolchain go1.24.4
 
 require (
 	github.com/alexellis/go-execute/v2 v2.2.1

--- a/iterator.go
+++ b/iterator.go
@@ -122,6 +122,8 @@ type Result struct {
 
 // RunForOrganization runs the processor for all repositories in an organization.
 func RunForOrganization(ctx context.Context, orgName string, searchOpts SearchOptions, processor Processor, opts Options) (Result, error) {
+	defer os.RemoveAll(reposDir) //nolint:errcheck
+
 	ctx, logger := setupLogger(ctx, opts)
 
 	ghArgs := []string{"api",

--- a/iterator.go
+++ b/iterator.go
@@ -122,8 +122,6 @@ type Result struct {
 
 // RunForOrganization runs the processor for all repositories in an organization.
 func RunForOrganization(ctx context.Context, orgName string, searchOpts SearchOptions, processor Processor, opts Options) (Result, error) {
-	defer os.RemoveAll(reposDir) //nolint:errcheck
-
 	ctx, logger := setupLogger(ctx, opts)
 
 	ghArgs := []string{"api",
@@ -160,6 +158,7 @@ func RunForOrganization(ctx context.Context, orgName string, searchOpts SearchOp
 		return Result{}, fmt.Errorf("fetching repositories: %w", github.ErrOrGHAPIErr(res, err))
 	}
 
+	// TODO: handle this over a channel to boost speed on processing.
 	repoPages, err := processRepoPages(res)
 	if err != nil {
 		return Result{}, fmt.Errorf("processing repositories pages: %w", err)
@@ -443,7 +442,7 @@ func processRepository(ctx context.Context, repo Repository, processor Processor
 	if repo.Size == 0 {
 		logger.Debug("Empty repository")
 
-		if err := processor(processCtx, repo.Name, true, exec.NewExecer("", false)); err != nil {
+		if err := processor(processCtx, repo.Name, true, exec.NewExecer("")); err != nil {
 			return fmt.Errorf("processing empty repository: %w", err)
 		}
 	}


### PR DESCRIPTION
Before exec.Execer was a concrete type with private fields which did not allow users to mock it. After this change exec.Execer becomes an interface and we will be able to mock and test it. Also exec.Result becomes a struct which eases the creation of mocked results and overall simplifies the API.

As a side effect, immutable functions like FS or WithEnv became struct methods to let the implementor to decide how to deal with this functions.