### PR TITLE
feat: adds cloneability test before running.

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -242,6 +242,10 @@ func runForReposConcurrently(ctx context.Context, repoPages [][]Repository, nOfW
 		return Result{}, nil
 	}
 
+	if err := checkCloneability(ctx, repoPages, filterIn, opts.UseHTTPS); err != nil {
+		return Result{Found: mFound}, err
+	}
+
 	var (
 		repoC  = make(chan Repository, nOfWorkers)
 		errC   = make(chan error, nOfWorkers)
@@ -273,10 +277,6 @@ func runForReposConcurrently(ctx context.Context, repoPages [][]Repository, nOfW
 				}
 			}
 		}()
-	}
-
-	if err := checkCloneability(ctx, repoPages, filterIn, opts.UseHTTPS); err != nil {
-		return Result{Found: mFound}, err
 	}
 
 	go func() {

--- a/iterator.go
+++ b/iterator.go
@@ -194,14 +194,6 @@ func setupLogger(ctx context.Context, opts Options) (context.Context, *slog.Logg
 // checkCloneability tries to clone one of the repositories to ensure
 // that the authentication method works correctly.
 func checkCloneability(ctx context.Context, repoPages [][]Repository, filterIn func(Repository) bool, useHTTPS bool) error {
-	return checkCloneabilityWithExecer(ctx, repoPages, filterIn, useHTTPS, newExecerWithLogger)
-}
-
-func checkCloneabilityWithExecer(ctx context.Context, repoPages [][]Repository, filterIn func(Repository) bool, useHTTPS bool, execerFactory func(string, *slog.Logger) exec.Execer) error {
-	if len(repoPages) == 0 || len(repoPages[0]) == 0 {
-		return errors.New("no repositories to check cloneability")
-	}
-
 	var repo Repository
 	for _, rp := range repoPages {
 		for _, r := range rp {
@@ -215,6 +207,10 @@ func checkCloneabilityWithExecer(ctx context.Context, repoPages [][]Repository, 
 		}
 	}
 
+	if repo.Name == "" {
+		return errors.New("no repositories to check cloneability")
+	}
+
 	logger := log.FromCtx(ctx)
 	logger.Debug("Checking repository cloneability", "repository", repo.Name)
 
@@ -223,7 +219,7 @@ func checkCloneabilityWithExecer(ctx context.Context, repoPages [][]Repository, 
 		repoURL = repo.URL
 	}
 
-	xr := execerFactory(".", logger)
+	xr := newExecerWithLogger(".", logger)
 	_, err := xr.RunX(ctx, "git", "ls-remote", "--exit-code", repoURL)
 	if err != nil {
 		return fmt.Errorf("checking if repositories can be cloned: %w", err)
@@ -235,14 +231,7 @@ var newExecerWithLogger = exec.NewExecerWithLogger
 
 func runForReposConcurrently(ctx context.Context, repoPages [][]Repository, nOfWorkers int, filterIn func(Repository) bool, processor Processor, opts Options) (Result, error) {
 	var (
-		repoC = make(chan Repository, nOfWorkers)
-		errC  = make(chan error, nOfWorkers)
-		doneC = make(chan struct{})
-		wg    = sync.WaitGroup{}
-
 		mFound, mInspected, mProcessed int
-		mMux                           sync.Mutex
-		logger                         = log.FromCtx(ctx)
 	)
 
 	for _, repoPage := range repoPages {
@@ -252,6 +241,15 @@ func runForReposConcurrently(ctx context.Context, repoPages [][]Repository, nOfW
 	if mFound == 0 {
 		return Result{}, nil
 	}
+
+	var (
+		repoC  = make(chan Repository, nOfWorkers)
+		errC   = make(chan error, nOfWorkers)
+		doneC  = make(chan struct{})
+		wg     = sync.WaitGroup{}
+		mMux   sync.Mutex
+		logger = log.FromCtx(ctx)
+	)
 
 	for range nOfWorkers {
 		wg.Add(1)

--- a/iterator.go
+++ b/iterator.go
@@ -191,6 +191,48 @@ func setupLogger(ctx context.Context, opts Options) (context.Context, *slog.Logg
 	return log.NewCtx(ctx, logger), logger
 }
 
+// checkCloneability tries to clone one of the repositories to ensure
+// that the authentication method works correctly.
+func checkCloneability(ctx context.Context, repoPages [][]Repository, filterIn func(Repository) bool, useHTTPS bool) error {
+	return checkCloneabilityWithExecer(ctx, repoPages, filterIn, useHTTPS, newExecerWithLogger)
+}
+
+func checkCloneabilityWithExecer(ctx context.Context, repoPages [][]Repository, filterIn func(Repository) bool, useHTTPS bool, execerFactory func(string, *slog.Logger) exec.Execer) error {
+	if len(repoPages) == 0 || len(repoPages[0]) == 0 {
+		return errors.New("no repositories to check cloneability")
+	}
+
+	var repo Repository
+	for _, rp := range repoPages {
+		for _, r := range rp {
+			if filterIn(r) {
+				repo = r
+				break
+			}
+		}
+		if repo.Name != "" {
+			break
+		}
+	}
+
+	logger := log.FromCtx(ctx)
+	logger.Debug("Checking repository cloneability", "repository", repo.Name)
+
+	repoURL := repo.SSHURL
+	if useHTTPS {
+		repoURL = repo.URL
+	}
+
+	xr := execerFactory(".", logger)
+	_, err := xr.RunX(ctx, "git", "ls-remote", "--exit-code", repoURL)
+	if err != nil {
+		return fmt.Errorf("checking if repositories can be cloned: %w", err)
+	}
+	return nil
+}
+
+var newExecerWithLogger = exec.NewExecerWithLogger
+
 func runForReposConcurrently(ctx context.Context, repoPages [][]Repository, nOfWorkers int, filterIn func(Repository) bool, processor Processor, opts Options) (Result, error) {
 	var (
 		repoC = make(chan Repository, nOfWorkers)
@@ -205,6 +247,10 @@ func runForReposConcurrently(ctx context.Context, repoPages [][]Repository, nOfW
 
 	for _, repoPage := range repoPages {
 		mFound += len(repoPage)
+	}
+
+	if mFound == 0 {
+		return Result{}, nil
 	}
 
 	for range nOfWorkers {
@@ -229,6 +275,10 @@ func runForReposConcurrently(ctx context.Context, repoPages [][]Repository, nOfW
 				}
 			}
 		}()
+	}
+
+	if err := checkCloneability(ctx, repoPages, filterIn, opts.UseHTTPS); err != nil {
+		return Result{Found: mFound}, err
 	}
 
 	go func() {

--- a/iterator_cloneability_test.go
+++ b/iterator_cloneability_test.go
@@ -1,0 +1,122 @@
+package iterator
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/jcchavezs/gh-iterator/exec"
+	"github.com/jcchavezs/gh-iterator/exec/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckCloneability(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("empty repo pages returns error", func(t *testing.T) {
+		mockFactory := func(string, *slog.Logger) exec.Execer {
+			return mock.Execer{}
+		}
+		err := checkCloneabilityWithExecer(ctx, [][]Repository{}, func(Repository) bool { return true }, false, mockFactory)
+		require.Error(t, err)
+		require.EqualError(t, err, "no repositories to check cloneability")
+	})
+
+	t.Run("successful cloneability check with SSH", func(t *testing.T) {
+		repoPages := [][]Repository{
+			{
+				{
+					Name:   "test-org/test-repo",
+					SSHURL: "git@github.com:test-org/test-repo.git",
+					URL:    "https://github.com/test-org/test-repo.git",
+				},
+			},
+		}
+
+		var capturedCommand string
+		var capturedArgs []string
+
+		mockFactory := func(string, *slog.Logger) exec.Execer {
+			return mock.Execer{
+				RunXFn: func(ctx context.Context, command string, args ...string) (string, error) {
+					capturedCommand = command
+					capturedArgs = args
+					return "", nil
+				},
+			}
+		}
+
+		err := checkCloneabilityWithExecer(ctx, repoPages, func(Repository) bool { return true }, false, mockFactory)
+		require.NoError(t, err)
+
+		require.Equal(t, "git", capturedCommand)
+
+		expectedArgs := []string{"ls-remote", "--exit-code", "git@github.com:test-org/test-repo.git"}
+		require.Equal(t, expectedArgs, capturedArgs)
+	})
+
+	t.Run("failed cloneability check", func(t *testing.T) {
+		repoPages := [][]Repository{
+			{
+				{
+					Name:   "test-org/test-repo",
+					SSHURL: "git@github.com:test-org/test-repo.git",
+					URL:    "https://github.com/test-org/test-repo.git",
+				},
+			},
+		}
+
+		mockErr := errors.New("authentication failed")
+		mockFactory := func(string, *slog.Logger) exec.Execer {
+			return mock.Execer{
+				RunXFn: func(ctx context.Context, command string, args ...string) (string, error) {
+					return "", mockErr
+				},
+			}
+		}
+
+		err := checkCloneabilityWithExecer(ctx, repoPages, func(Repository) bool { return true }, false, mockFactory)
+		require.Error(t, err)
+		require.ErrorIs(t, err, mockErr)
+	})
+
+	t.Run("filters out repositories correctly", func(t *testing.T) {
+		repoPages := [][]Repository{
+			{
+				{
+					Name: "test-org/archived-repo",
+				},
+				{
+					Name:   "test-org/active-repo",
+					SSHURL: "git@github.com:test-org/active-repo.git",
+					URL:    "https://github.com/test-org/active-repo.git",
+				},
+			},
+		}
+
+		var capturedArgs []string
+
+		mockFactory := func(string, *slog.Logger) exec.Execer {
+			return mock.Execer{
+				RunXFn: func(ctx context.Context, command string, args ...string) (string, error) {
+					capturedArgs = args
+					return "", nil
+				},
+			}
+		}
+
+		// Filter that only accepts "active-repo"
+		filterIn := func(r Repository) bool {
+			return r.Name == "test-org/active-repo"
+		}
+
+		err := checkCloneabilityWithExecer(ctx, repoPages, filterIn, false, mockFactory)
+		require.NoError(t, err)
+
+		// Should use the active-repo URL, not the archived one
+		expectedURL := "git@github.com:test-org/active-repo.git"
+		require.GreaterOrEqual(t, len(capturedArgs), 3)
+		require.Equal(t, expectedURL, capturedArgs[2])
+	})
+}

--- a/iterator_cloneability_test.go
+++ b/iterator_cloneability_test.go
@@ -11,14 +11,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func overrideExecerFactory(t *testing.T, execFactory func(string, *slog.Logger) exec.Execer) {
+	t.Helper()
+	oldFactory := newExecerWithLogger
+	newExecerWithLogger = execFactory
+	t.Cleanup(func() {
+		newExecerWithLogger = oldFactory
+	})
+}
+
 func TestCheckCloneability(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("empty repo pages returns error", func(t *testing.T) {
-		mockFactory := func(string, *slog.Logger) exec.Execer {
+		overrideExecerFactory(t, func(string, *slog.Logger) exec.Execer {
 			return mock.Execer{}
-		}
-		err := checkCloneabilityWithExecer(ctx, [][]Repository{}, func(Repository) bool { return true }, false, mockFactory)
+		})
+
+		err := checkCloneability(ctx, [][]Repository{}, func(Repository) bool { return true }, false)
 		require.Error(t, err)
 		require.EqualError(t, err, "no repositories to check cloneability")
 	})
@@ -37,7 +47,7 @@ func TestCheckCloneability(t *testing.T) {
 		var capturedCommand string
 		var capturedArgs []string
 
-		mockFactory := func(string, *slog.Logger) exec.Execer {
+		overrideExecerFactory(t, func(string, *slog.Logger) exec.Execer {
 			return mock.Execer{
 				RunXFn: func(ctx context.Context, command string, args ...string) (string, error) {
 					capturedCommand = command
@@ -45,9 +55,9 @@ func TestCheckCloneability(t *testing.T) {
 					return "", nil
 				},
 			}
-		}
+		})
 
-		err := checkCloneabilityWithExecer(ctx, repoPages, func(Repository) bool { return true }, false, mockFactory)
+		err := checkCloneability(ctx, repoPages, func(Repository) bool { return true }, false)
 		require.NoError(t, err)
 
 		require.Equal(t, "git", capturedCommand)
@@ -68,15 +78,15 @@ func TestCheckCloneability(t *testing.T) {
 		}
 
 		mockErr := errors.New("authentication failed")
-		mockFactory := func(string, *slog.Logger) exec.Execer {
+		overrideExecerFactory(t, func(string, *slog.Logger) exec.Execer {
 			return mock.Execer{
 				RunXFn: func(ctx context.Context, command string, args ...string) (string, error) {
 					return "", mockErr
 				},
 			}
-		}
+		})
 
-		err := checkCloneabilityWithExecer(ctx, repoPages, func(Repository) bool { return true }, false, mockFactory)
+		err := checkCloneability(ctx, repoPages, func(Repository) bool { return true }, false)
 		require.Error(t, err)
 		require.ErrorIs(t, err, mockErr)
 	})
@@ -97,21 +107,21 @@ func TestCheckCloneability(t *testing.T) {
 
 		var capturedArgs []string
 
-		mockFactory := func(string, *slog.Logger) exec.Execer {
+		overrideExecerFactory(t, func(string, *slog.Logger) exec.Execer {
 			return mock.Execer{
 				RunXFn: func(ctx context.Context, command string, args ...string) (string, error) {
 					capturedArgs = args
 					return "", nil
 				},
 			}
-		}
+		})
 
 		// Filter that only accepts "active-repo"
 		filterIn := func(r Repository) bool {
 			return r.Name == "test-org/active-repo"
 		}
 
-		err := checkCloneabilityWithExecer(ctx, repoPages, filterIn, false, mockFactory)
+		err := checkCloneability(ctx, repoPages, filterIn, false)
 		require.NoError(t, err)
 
 		// Should use the active-repo URL, not the archived one

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -2,13 +2,16 @@ package iterator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"sync"
 	"testing"
 
 	"github.com/jcchavezs/gh-iterator/exec"
+	"github.com/jcchavezs/gh-iterator/exec/mock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 )
@@ -35,6 +38,19 @@ func TestFillLines(t *testing.T) {
 
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
+}
+
+func mockLSRemoteCheck(t *testing.T) {
+	overrideExecerFactory(t, func(s string, l *slog.Logger) exec.Execer {
+		return mock.Execer{
+			RunXFn: func(ctx context.Context, command string, args ...string) (string, error) {
+				if command == "git" && len(args) >= 3 && args[0] == "ls-remote" {
+					return "", nil
+				}
+				return "", errors.New("unexpected command")
+			},
+		}
+	})
 }
 
 func TestRunForReposConcurrently(t *testing.T) {
@@ -64,6 +80,8 @@ func TestRunForReposConcurrently(t *testing.T) {
 	opts := Options{
 		Debug: true,
 	}
+
+	mockLSRemoteCheck(t)
 
 	result, err := runForReposConcurrently(ctx, repoPages, nOfWorkers, func(repo Repository) bool { return true }, processor, opts)
 	require.NoError(t, err)
@@ -108,6 +126,8 @@ func TestRunForReposConcurrentlyFilteredRepos(t *testing.T) {
 		return repo.Language == "Go"
 	}
 
+	mockLSRemoteCheck(t)
+
 	result, err := runForReposConcurrently(ctx, repoPages, nOfWorkers, filterIn, processor, opts)
 	require.NoError(t, err)
 	require.Equal(t, 3, result.Found)
@@ -129,9 +149,7 @@ func TestRunForReposConcurrentlyEmptyRepos(t *testing.T) {
 		return nil
 	}
 
-	opts := Options{
-		Debug: true,
-	}
+	opts := Options{}
 
 	result, err := runForReposConcurrently(ctx, repoPages, nOfWorkers, func(repo Repository) bool { return true }, processor, opts)
 	require.NoError(t, err)
@@ -159,9 +177,8 @@ func TestRunForReposConcurrentlyContextCancelled(t *testing.T) {
 		return nil
 	}
 
-	opts := Options{
-		Debug: true,
-	}
+	opts := Options{}
+	mockLSRemoteCheck(t)
 
 	_, err := runForReposConcurrently(ctx, repoPages, nOfWorkers, func(repo Repository) bool { return true }, processor, opts)
 
@@ -186,9 +203,9 @@ func TestRunForReposConcurrentlyErrorInProcessor(t *testing.T) {
 		return nil
 	}
 
-	opts := Options{
-		Debug: true,
-	}
+	opts := Options{}
+
+	mockLSRemoteCheck(t)
 
 	_, err := runForReposConcurrently(ctx, repoPages, nOfWorkers, func(repo Repository) bool { return true }, processor, opts)
 	require.Error(t, err)

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -41,6 +41,7 @@ func TestMain(m *testing.M) {
 }
 
 func mockLSRemoteCheck(t *testing.T) {
+	t.Helper()
 	overrideExecerFactory(t, func(s string, l *slog.Logger) exec.Execer {
 		return mock.Execer{
 			RunXFn: func(ctx context.Context, command string, args ...string) (string, error) {


### PR DESCRIPTION
In some setups, we need to authenticate through browser before cloning and since we support concurrent clonings we would trigger <number of workers> browser tabs which is akward experience. With this change we check the cloneability for the first repository, asserting we can cloning the rest.