### PR TITLE
feat: adds a method for listing organizations.

### DIFF
--- a/examples/listrepos/main.go
+++ b/examples/listrepos/main.go
@@ -1,0 +1,59 @@
+package main
+
+// This example lists all repositories for a given organization and checks if they have a dependabot manifest.
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	iterator "github.com/jcchavezs/gh-iterator"
+	iteratorexec "github.com/jcchavezs/gh-iterator/exec"
+)
+
+func main() {
+	var (
+		boardMux sync.Mutex
+		onboard  = 0
+		offboard = 0
+	)
+
+	res, err := iterator.ListForOrganization(
+		context.Background(),
+		"jcchavezs",
+		iterator.SearchOptions{
+			Page: iterator.AllPages,
+		},
+		func(ctx context.Context, xr iteratorexec.Execer, repo string) error {
+			path := ".github/dependabot.yml"
+
+			res, err := xr.Run(ctx, "gh", "api", fmt.Sprintf("/repos/%s/contents/%s", repo, path))
+			if err != nil {
+				xr.Log(ctx, slog.LevelError, "Failed to read dependabot manifest")
+				return nil
+			}
+
+			boardMux.Lock()
+			defer boardMux.Unlock()
+
+			if res.ExitCode == 0 {
+				onboard++
+			} else {
+				offboard++
+			}
+
+			return nil
+		}, iterator.ListOptions{
+			NumberOfWorkers: 5,
+		},
+	)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+
+	fmt.Printf("Total repositories: %d\n", res.Processed)
+	fmt.Printf("Onboarded repositories: %d\n", onboard)
+	fmt.Printf("Offboarded repositories: %d\n", offboard)
+}

--- a/github/github.go
+++ b/github/github.go
@@ -315,6 +315,11 @@ func getCurrentUser(ctx context.Context, xr iteratorexec.Execer) (string, error)
 	return res, nil
 }
 
+type ghAPIErrorResponse struct {
+	Message string `json:"message"`
+	Status  string `json:"status"`
+}
+
 func IsRepositoryArchived(ctx context.Context, repoName string, xr iteratorexec.Execer) (bool, error) {
 	xr.Log(ctx, slog.LevelDebug, "Checking if repository is archived")
 
@@ -322,9 +327,14 @@ func IsRepositoryArchived(ctx context.Context, repoName string, xr iteratorexec.
 		fmt.Sprintf("/repos/%s", repoName),
 		"-H", "Accept: application/vnd.github+json",
 		"--jq", ".archived")
-	if err != nil {
-		return false, fmt.Errorf("checking if repository is archived: %w", err)
+	if err == nil {
+		return strings.Contains(res, "true"), nil
 	}
 
-	return strings.Contains(res, "true"), nil
+	var errResponse ghAPIErrorResponse
+	if err := json.Unmarshal([]byte(res), &errResponse); err == nil {
+		return false, fmt.Errorf("checking if repository is archived: %s", errResponse.Message)
+	}
+
+	return false, fmt.Errorf("checking if repository is archived: %w", err)
 }

--- a/iterator.go
+++ b/iterator.go
@@ -61,6 +61,9 @@ func CloneCacheKeyFromString(s string) CloneCacheKey {
 	return func(Repository) string { return s }
 }
 
+// RunOptions are the options to run the iterator.
+type RunOptions = Options
+
 // Options are the options to run the iterator.
 type Options struct {
 	// UseHTTPS is a flag to use HTTPS instead of SSH to clone the repositories.
@@ -90,8 +93,9 @@ const (
 	GithubAPIVersion       = "2022-11-28"
 )
 
-func processRepoPages(s string) ([][]Repository, error) {
-	ls := bufio.NewScanner(strings.NewReader(s))
+// processRepoPages processes the repository pages returned by the GitHub API and returns a slice of repositories.
+func processRepoPages(payload string) ([][]Repository, error) {
+	ls := bufio.NewScanner(strings.NewReader(payload))
 	ls.Split(bufio.ScanLines)
 	var repoPages [][]Repository
 	for ls.Scan() {
@@ -125,11 +129,30 @@ type Result struct {
 }
 
 // RunForOrganization runs the processor for all repositories in an organization.
-func RunForOrganization(ctx context.Context, orgName string, searchOpts SearchOptions, processor Processor, opts Options) (Result, error) {
+func RunForOrganization(ctx context.Context, orgName string, searchOpts SearchOptions, processor Processor, opts RunOptions) (Result, error) {
 	defer os.RemoveAll(reposDir) //nolint:errcheck
 
-	ctx, logger := setupLogger(ctx, opts)
+	ctx, logger := setupLogger(ctx, opts.LogHandler, opts.Debug)
 
+	repoPages, err := getRepoPages(ctx, searchOpts, orgName, logger)
+	if err != nil {
+		return Result{}, err
+	}
+
+	filterIn := searchOpts.MakeFilterIn()
+	if err := checkCloneability(ctx, repoPages, filterIn, opts.UseHTTPS); err != nil {
+		return Result{Found: countRepoPages(repoPages)}, err
+	}
+
+	var nOfWorkers = defaultNumberOfWorkers
+	if opts.NumberOfWorkers > 0 {
+		nOfWorkers = opts.NumberOfWorkers
+	}
+
+	return runForReposConcurrently(ctx, repoPages, nOfWorkers, filterIn, processRepository, processor, opts)
+}
+
+func getRepoPages(ctx context.Context, searchOpts SearchOptions, orgName string, logger *slog.Logger) ([][]Repository, error) {
 	ghArgs := []string{"api",
 		"-H", "Accept: application/vnd.github+json",
 		"-H", "X-GitHub-Api-Version: " + GithubAPIVersion,
@@ -147,7 +170,7 @@ func RunForOrganization(ctx context.Context, orgName string, searchOpts SearchOp
 	} else if searchOpts.PerPage > 0 {
 		target = fmt.Sprintf("%s?per_page=%d", target, searchOpts.PerPage)
 	} else {
-		return Result{}, errors.New("invalid negative SearchOptions.PerPage")
+		return nil, errors.New("invalid negative SearchOptions.PerPage")
 	}
 
 	if searchOpts.Page == AllPages {
@@ -155,34 +178,29 @@ func RunForOrganization(ctx context.Context, orgName string, searchOpts SearchOp
 	} else if searchOpts.Page > 0 {
 		target = fmt.Sprintf("%s&page=%d", target, searchOpts.Page)
 	} else if searchOpts.Page != 0 {
-		return Result{}, errors.New("invalid negative SearchOptions.Page")
+		return nil, errors.New("invalid negative SearchOptions.Page")
 	}
 
 	x := exec.NewExecerWithLogger(".", logger)
 	res, err := x.RunX(ctx, "gh", append(ghArgs, target)...)
 	if err != nil {
-		return Result{}, fmt.Errorf("fetching repositories: %w", github.ErrOrGHAPIErr(res, err))
+		return nil, fmt.Errorf("fetching repositories: %w", github.ErrOrGHAPIErr(res, err))
 	}
 
 	// TODO: handle this over a channel to boost speed on processing.
 	repoPages, err := processRepoPages(res)
 	if err != nil {
-		return Result{}, fmt.Errorf("processing repositories pages: %w", err)
+		return nil, fmt.Errorf("processing repositories pages: %w", err)
 	}
 
-	var nOfWorkers = defaultNumberOfWorkers
-	if opts.NumberOfWorkers > 0 {
-		nOfWorkers = opts.NumberOfWorkers
-	}
-
-	return runForReposConcurrently(ctx, repoPages, nOfWorkers, searchOpts.MakeFilterIn(), processor, opts)
+	return repoPages, nil
 }
 
-func setupLogger(ctx context.Context, opts Options) (context.Context, *slog.Logger) {
+func setupLogger(ctx context.Context, logHandler slog.Handler, debug bool) (context.Context, *slog.Logger) {
 	var logger *slog.Logger
-	if opts.LogHandler != nil {
-		logger = slog.New(opts.LogHandler)
-	} else if opts.Debug {
+	if logHandler != nil {
+		logger = slog.New(logHandler)
+	} else if debug {
 		logger = slog.Default()
 	} else {
 		logger = slog.New(log.DiscardHandler)
@@ -229,21 +247,32 @@ func checkCloneability(ctx context.Context, repoPages [][]Repository, filterIn f
 
 var newExecerWithLogger = exec.NewExecerWithLogger
 
-func runForReposConcurrently(ctx context.Context, repoPages [][]Repository, nOfWorkers int, filterIn func(Repository) bool, processor Processor, opts Options) (Result, error) {
-	var (
-		mFound, mInspected, mProcessed int
-	)
-
+// countRepoPages counts the total number of repositories in the pages.
+func countRepoPages(repoPages [][]Repository) int {
+	var mFound int
 	for _, repoPage := range repoPages {
 		mFound += len(repoPage)
 	}
+	return mFound
+}
+
+// runForReposConcurrently runs the processor for the repositories concurrently using nOfWorkers workers.
+func runForReposConcurrently(
+	ctx context.Context,
+	repoPages [][]Repository,
+	nOfWorkers int,
+	filterIn func(Repository) bool,
+	processorCaller func(context.Context, Repository, Processor, RunOptions) error,
+	processor Processor,
+	opts RunOptions,
+) (Result, error) {
+	var (
+		mFound                 = countRepoPages(repoPages)
+		mInspected, mProcessed int
+	)
 
 	if mFound == 0 {
 		return Result{}, nil
-	}
-
-	if err := checkCloneability(ctx, repoPages, filterIn, opts.UseHTTPS); err != nil {
-		return Result{Found: mFound}, err
 	}
 
 	var (
@@ -265,7 +294,7 @@ func runForReposConcurrently(ctx context.Context, repoPages [][]Repository, nOfW
 					// if the context is cancelled we do not process any more repositories
 					continue
 				default:
-					if err := processRepository(ctx, repo, processor, opts); err != nil {
+					if err := processorCaller(ctx, repo, processor, opts); err != nil {
 						if errors.Is(err, errNoDefaultBranch) {
 							logger.Warn("Repository with no default branch", "repository", repo.Name)
 							continue
@@ -338,12 +367,12 @@ func runForReposConcurrently(ctx context.Context, repoPages [][]Repository, nOfW
 }
 
 // RunForRepository runs the processor for a single repository.
-func RunForRepository(ctx context.Context, repoName string, processor Processor, opts Options) error {
+func RunForRepository(ctx context.Context, repoName string, processor Processor, opts RunOptions) error {
 	if strings.Count(repoName, "/") > 1 {
 		return fmt.Errorf("incorrect repository name %q", repoName)
 	}
 
-	ctx, logger := setupLogger(ctx, opts)
+	ctx, logger := setupLogger(ctx, opts.LogHandler, opts.Debug)
 
 	x := exec.NewExecerWithLogger(".", logger)
 
@@ -377,11 +406,12 @@ var (
 	errNoDefaultBranch = errors.New("no default branch")
 )
 
+// hashCloningSubset generates a hash for the cloning subset to be used as part of the cache key when cloning repositories with a subset of files or directories.
 func hashCloningSubset(cs []string) string {
 	return fmt.Sprintf("%x", md5.Sum([]byte(strings.Join(cs, "|"))))[:16]
 }
 
-func cloneRepositoryOrGetFromCache(ctx context.Context, repo Repository, opts Options) (string, error) {
+func cloneRepositoryOrGetFromCache(ctx context.Context, repo Repository, opts RunOptions) (string, error) {
 	logger := log.FromCtx(ctx)
 
 	var (
@@ -442,7 +472,8 @@ func cloneRepositoryOrGetFromCache(ctx context.Context, repo Repository, opts Op
 	return repoDir, nil
 }
 
-func cloneRepository(ctx context.Context, repo Repository, repoDir string, opts Options) error {
+// cloneRepository clones the repository to the given directory.
+func cloneRepository(ctx context.Context, repo Repository, repoDir string, opts RunOptions) error {
 	logger := log.FromCtx(ctx)
 
 	x := exec.NewExecerWithLogger(repoDir, logger)
@@ -486,7 +517,7 @@ func cloneRepository(ctx context.Context, repo Repository, repoDir string, opts 
 	return nil
 }
 
-func processRepository(ctx context.Context, repo Repository, processor Processor, opts Options) error {
+func processRepository(ctx context.Context, repo Repository, processor Processor, opts RunOptions) error {
 	logger := log.FromCtx(ctx).With("repository", repo.Name)
 
 	processCtx := log.NewCtx(ctx, logger)

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -84,7 +84,7 @@ func TestRunForReposConcurrently(t *testing.T) {
 
 	mockLSRemoteCheck(t)
 
-	result, err := runForReposConcurrently(ctx, repoPages, nOfWorkers, func(repo Repository) bool { return true }, processor, opts)
+	result, err := runForReposConcurrently(ctx, repoPages, nOfWorkers, func(repo Repository) bool { return true }, processRepository, processor, opts)
 	require.NoError(t, err)
 	require.Equal(t, 1000, result.Found)
 	require.Equal(t, 1000, result.Inspected)
@@ -129,7 +129,7 @@ func TestRunForReposConcurrentlyFilteredRepos(t *testing.T) {
 
 	mockLSRemoteCheck(t)
 
-	result, err := runForReposConcurrently(ctx, repoPages, nOfWorkers, filterIn, processor, opts)
+	result, err := runForReposConcurrently(ctx, repoPages, nOfWorkers, filterIn, processRepository, processor, opts)
 	require.NoError(t, err)
 	require.Equal(t, 3, result.Found)
 	require.Equal(t, 3, result.Inspected)
@@ -152,7 +152,7 @@ func TestRunForReposConcurrentlyEmptyRepos(t *testing.T) {
 
 	opts := Options{}
 
-	result, err := runForReposConcurrently(ctx, repoPages, nOfWorkers, func(repo Repository) bool { return true }, processor, opts)
+	result, err := runForReposConcurrently(ctx, repoPages, nOfWorkers, func(repo Repository) bool { return true }, processRepository, processor, opts)
 	require.NoError(t, err)
 	require.Equal(t, 0, result.Found)
 	require.Equal(t, 0, result.Inspected)
@@ -181,7 +181,7 @@ func TestRunForReposConcurrentlyContextCancelled(t *testing.T) {
 	opts := Options{}
 	mockLSRemoteCheck(t)
 
-	_, err := runForReposConcurrently(ctx, repoPages, nOfWorkers, func(repo Repository) bool { return true }, processor, opts)
+	_, err := runForReposConcurrently(ctx, repoPages, nOfWorkers, func(repo Repository) bool { return true }, processRepository, processor, opts)
 
 	require.ErrorIs(t, err, context.Canceled)
 }
@@ -208,7 +208,7 @@ func TestRunForReposConcurrentlyErrorInProcessor(t *testing.T) {
 
 	mockLSRemoteCheck(t)
 
-	_, err := runForReposConcurrently(ctx, repoPages, nOfWorkers, func(repo Repository) bool { return true }, processor, opts)
+	_, err := runForReposConcurrently(ctx, repoPages, nOfWorkers, func(repo Repository) bool { return true }, processRepository, processor, opts)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "error processing repo2")
 }

--- a/list.go
+++ b/list.go
@@ -1,0 +1,60 @@
+package iterator
+
+import (
+	"context"
+	"log/slog"
+
+	iteratorexec "github.com/jcchavezs/gh-iterator/exec"
+	"github.com/jcchavezs/gh-iterator/internal/log"
+)
+
+type ListOptions struct {
+	// NumberOfWorkers is the number of workers to process the repositories concurrently, by default it
+	// uses 10 workers. Only valid when calling `RunForOrganization``
+	NumberOfWorkers int
+
+	// Log handler
+	LogHandler slog.Handler
+}
+
+// ListForOrganization lists the repositories for the given organization and processes them concurrently using the provided callback function.
+// It returns a Result struct with the number of repositories found and inspected, or an error if any occurs during the process.
+func ListForOrganization(ctx context.Context, orgName string, searchOpts SearchOptions, callback func(context.Context, iteratorexec.Execer, string) error, opts ListOptions) (Result, error) {
+	ctx, logger := setupLogger(ctx, opts.LogHandler, false)
+
+	repoPages, err := getRepoPages(ctx, searchOpts, orgName, logger)
+	if err != nil {
+		return Result{}, err
+	}
+
+	nOfWorkers := opts.NumberOfWorkers
+	if nOfWorkers <= 0 {
+		nOfWorkers = defaultNumberOfWorkers
+	}
+
+	filterIn := searchOpts.MakeFilterIn()
+	xr := iteratorexec.NewExecerWithLogger("", logger)
+
+	return runForReposConcurrently(
+		ctx,
+		repoPages,
+		nOfWorkers,
+		filterIn,
+		func(ctx context.Context, repo Repository, processor Processor, opts Options) error {
+			logger := log.FromCtx(ctx).With("repository", repo.Name)
+			processCtx := log.NewCtx(ctx, logger)
+
+			if err := processor(processCtx, repo.Name, repo.Size == 0, xr); err != nil {
+				return err
+			}
+
+			return nil
+		},
+		func(ctx context.Context, repository string, isEmpty bool, xr iteratorexec.Execer) error {
+			return callback(ctx, xr, repository)
+		}, RunOptions{
+			NumberOfWorkers: opts.NumberOfWorkers,
+			LogHandler:      opts.LogHandler,
+		},
+	)
+}

--- a/list.go
+++ b/list.go
@@ -10,7 +10,7 @@ import (
 
 type ListOptions struct {
 	// NumberOfWorkers is the number of workers to process the repositories concurrently, by default it
-	// uses 10 workers. Only valid when calling `RunForOrganization``
+	// uses 10 workers.
 	NumberOfWorkers int
 
 	// Log handler
@@ -19,7 +19,7 @@ type ListOptions struct {
 
 // ListForOrganization lists the repositories for the given organization and processes them concurrently using the provided callback function.
 // It returns a Result struct with the number of repositories found and inspected, or an error if any occurs during the process.
-func ListForOrganization(ctx context.Context, orgName string, searchOpts SearchOptions, callback func(context.Context, iteratorexec.Execer, string) error, opts ListOptions) (Result, error) {
+func ListForOrganization(ctx context.Context, orgName string, searchOpts SearchOptions, callback func(ctx context.Context, xr iteratorexec.Execer, repository string) error, opts ListOptions) (Result, error) {
 	ctx, logger := setupLogger(ctx, opts.LogHandler, false)
 
 	repoPages, err := getRepoPages(ctx, searchOpts, orgName, logger)
@@ -44,7 +44,7 @@ func ListForOrganization(ctx context.Context, orgName string, searchOpts SearchO
 			logger := log.FromCtx(ctx).With("repository", repo.Name)
 			processCtx := log.NewCtx(ctx, logger)
 
-			if err := processor(processCtx, repo.Name, repo.Size == 0, xr); err != nil {
+			if err := processor(processCtx, repo.Name, repo.Size == 0, xr.WithEnv("GH_REPO", repo.Name)); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
Added a new `ListForOrganization` function in `list.go` to provide a simple, high-level API for listing and processing repositories in an organization concurrently, with customizable worker count and logging. This is accompanied by a new `ListOptions` struct for configuration.

Sometimes we need to obtain metrics that do not require to clone the repository and just consume gh API.

**Documentation and examples:**

* Added a new example program in `examples/listrepos/main.go` demonstrating how to use the new `ListForOrganization` API to list repositories and check for a Dependabot manifest.