### PR TITLE
feat: PR assignees

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -162,7 +162,7 @@ type PROptions struct {
 	Draft bool
 	// The branch that contains commits for your pull request
 	Head string
-	// Assignees' logins for the pull request
+	// Assignees' logins for the pull request. If the PR already exists, the assignees will be added to the existing ones.
 	Assignees []string
 }
 
@@ -192,10 +192,10 @@ func CreatePRIfNotExist(ctx context.Context, xr iteratorexec.Execer, opts PROpti
 	}
 
 	var (
-		prURL       string
-		isNewPR     bool
-		isDraft     bool
-		prAssignees []string
+		prURL              string
+		isNewPR            bool
+		isDraft            bool
+		currentPRAssignees []string
 	)
 
 	// Passing the head ref to check if the PR exists. This is necessary when
@@ -211,10 +211,10 @@ func CreatePRIfNotExist(ctx context.Context, xr iteratorexec.Execer, opts PROpti
 	} else if res.ExitCode == 0 {
 		// PR exists
 		var pr struct {
-			URL       string   `json:"url"`
-			State     string   `json:"state"`
-			IsDraft   bool     `json:"isDraft"`
-			Assignees []struct{
+			URL       string `json:"url"`
+			State     string `json:"state"`
+			IsDraft   bool   `json:"isDraft"`
+			Assignees []struct {
 				Login string `json:"login"`
 			} `json:"assignees"`
 		}
@@ -225,9 +225,9 @@ func CreatePRIfNotExist(ctx context.Context, xr iteratorexec.Execer, opts PROpti
 
 		isDraft = pr.IsDraft
 		if len(pr.Assignees) > 0 {
-			prAssignees = make([]string, len(pr.Assignees))
+			currentPRAssignees = make([]string, len(pr.Assignees))
 			for i, a := range pr.Assignees {
-				prAssignees[i] = a.Login
+				currentPRAssignees[i] = a.Login
 			}
 		}
 
@@ -285,7 +285,7 @@ func CreatePRIfNotExist(ctx context.Context, xr iteratorexec.Execer, opts PROpti
 
 		if len(opts.Assignees) > 0 {
 			for _, assignee := range opts.Assignees {
-				if !slices.Contains(prAssignees, assignee) {
+				if !slices.Contains(currentPRAssignees, assignee) {
 					editPRArgs = append(editPRArgs, "--add-assignee", assignee)
 				}
 			}

--- a/github/github.go
+++ b/github/github.go
@@ -125,6 +125,7 @@ func Commit(ctx context.Context, xr iteratorexec.Execer, message string, flags .
 	return wrapErrIfNotNil("commiting changes: %w", err)
 }
 
+// PushOption represents the options for pushing changes to the remote repository.
 type PushOption bool
 
 const (
@@ -151,15 +152,18 @@ func PushToRemote(ctx context.Context, xr iteratorexec.Execer, remoteName string
 	return wrapErrIfNotNil("pushing changes: %w", err)
 }
 
+// PROptions contains the options for creating a pull request. It is used in CreatePRIfNotExist.
 type PROptions struct {
 	// Title for the pull request
 	Title string
 	// Body for the pull request
 	Body string
-	// Draft will open the PR as draft when true
+	// Draft will open the pull request as draft when true
 	Draft bool
 	// The branch that contains commits for your pull request
 	Head string
+	// Assignees' logins for the pull request
+	Assignees []string
 }
 
 const prBodyMaxLen = 5000 // arbitrary but I think it is enough
@@ -188,9 +192,10 @@ func CreatePRIfNotExist(ctx context.Context, xr iteratorexec.Execer, opts PROpti
 	}
 
 	var (
-		prURL   string
-		isNewPR bool
-		isDraft bool
+		prURL       string
+		isNewPR     bool
+		isDraft     bool
+		prAssignees []string
 	)
 
 	// Passing the head ref to check if the PR exists. This is necessary when
@@ -206,9 +211,12 @@ func CreatePRIfNotExist(ctx context.Context, xr iteratorexec.Execer, opts PROpti
 	} else if res.ExitCode == 0 {
 		// PR exists
 		var pr struct {
-			URL     string `json:"url"`
-			State   string `json:"state"`
-			IsDraft bool   `json:"isDraft"`
+			URL       string   `json:"url"`
+			State     string   `json:"state"`
+			IsDraft   bool     `json:"isDraft"`
+			Assignees []struct{
+				Login string `json:"login"`
+			} `json:"assignees"`
 		}
 
 		if err := json.NewDecoder(strings.NewReader(res.Stdout)).Decode(&pr); err != nil {
@@ -216,6 +224,12 @@ func CreatePRIfNotExist(ctx context.Context, xr iteratorexec.Execer, opts PROpti
 		}
 
 		isDraft = pr.IsDraft
+		if len(pr.Assignees) > 0 {
+			prAssignees = make([]string, len(pr.Assignees))
+			for i, a := range pr.Assignees {
+				prAssignees[i] = a.Login
+			}
+		}
 
 		if pr.State != "CLOSED" && pr.State != "MERGED" {
 			// PR is not closed
@@ -224,7 +238,6 @@ func CreatePRIfNotExist(ctx context.Context, xr iteratorexec.Execer, opts PROpti
 	}
 
 	if prURL == "" {
-		xr.Log(ctx, slog.LevelInfo, "Creating PR")
 		// non Closed PR does not exist
 		createPRArgs := []string{"pr", "create"}
 		if prBodyFile != "" {
@@ -243,6 +256,11 @@ func CreatePRIfNotExist(ctx context.Context, xr iteratorexec.Execer, opts PROpti
 		if prBodyFile == "" || opts.Title == "" {
 			createPRArgs = append(createPRArgs, "--fill")
 		}
+		if len(opts.Assignees) > 0 {
+			for _, assignee := range opts.Assignees {
+				createPRArgs = append(createPRArgs, "--assignee", assignee)
+			}
+		}
 
 		res, err := xr.RunX(ctx, "gh", createPRArgs...)
 		if err != nil {
@@ -251,19 +269,29 @@ func CreatePRIfNotExist(ctx context.Context, xr iteratorexec.Execer, opts PROpti
 
 		prURL = strings.TrimSpace(res)
 		isNewPR = true
-	} else {
-		xr.Log(ctx, slog.LevelDebug, "PR exists already exists", "url", prURL)
 
-		createPRArgs := []string{"pr", "edit", prURL}
+		xr.Log(ctx, slog.LevelInfo, "PR created", "pr_url", prURL)
+	} else {
+		xr.Log(ctx, slog.LevelDebug, "PR already exists", "pr_url", prURL)
+
+		editPRArgs := []string{"pr", "edit", prURL}
 		if prBodyFile != "" {
-			createPRArgs = append(createPRArgs, "--body-file", prBodyFile)
+			editPRArgs = append(editPRArgs, "--body-file", prBodyFile)
 		}
 
 		if opts.Title != "" {
-			createPRArgs = append(createPRArgs, "--title", opts.Title)
+			editPRArgs = append(editPRArgs, "--title", opts.Title)
 		}
 
-		res, err := xr.RunX(ctx, "gh", createPRArgs...)
+		if len(opts.Assignees) > 0 {
+			for _, assignee := range opts.Assignees {
+				if !slices.Contains(prAssignees, assignee) {
+					editPRArgs = append(editPRArgs, "--add-assignee", assignee)
+				}
+			}
+		}
+
+		res, err := xr.RunX(ctx, "gh", editPRArgs...)
 		if err != nil {
 			return "", false, fmt.Errorf("failed to update PR: %w", ErrOrGHAPIErr(res, err))
 		}
@@ -320,6 +348,7 @@ type ghAPIErrorResponse struct {
 	Status  string `json:"status"`
 }
 
+// IsRepositoryArchived checks if the repository is archived by querying the GitHub API.
 func IsRepositoryArchived(ctx context.Context, repoName string, xr iteratorexec.Execer) (bool, error) {
 	xr.Log(ctx, slog.LevelDebug, "Checking if repository is archived")
 

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -201,6 +201,66 @@ func TestCreatePRIfNotExist(t *testing.T) {
 		require.Equal(t, true, isNewPR)
 		require.Equal(t, "https://github.com/jcchavezs/gh-iterator/pull/22", prURL)
 	})
+
+	t.Run("assignees", func(t *testing.T) {
+		t.Run("on new PR", func(t *testing.T) {
+			xr := mock.Execer{
+				RunFn: func(ctx context.Context, command string, args ...string) (iteratorexec.Result, error) {
+					return iteratorexec.Result{
+						ExitCode: 1,
+					}, nil
+				},
+				RunXFn: func(ctx context.Context, command string, args ...string) (string, error) {
+					t.Logf("RunX command: %s, args: %v", command, args)
+					require.Contains(t, args, "--assignee")
+					require.Contains(t, args, "testuser")
+					return "", nil
+				},
+				Logger: slog.New(slog.DiscardHandler),
+			}
+
+			_, _, err := CreatePRIfNotExist(context.Background(), xr, PROptions{
+				Title: "Test PR",
+				Body:  "This is a test PR",
+				Assignees: []string{"testuser"},
+			})
+			require.NoError(t, err)
+		})
+
+		t.Run("on existing PR", func(t *testing.T) {
+			xr := mock.Execer{
+				RunFn: func(ctx context.Context, command string, args ...string) (iteratorexec.Result, error) {
+					return iteratorexec.Result{
+						Stdout: `{
+							"url": "https://github.com/jcchavezs/gh-iterator/pull/21",
+							"state": "OPEN",
+							"isDraft": false,
+							"assignees": [
+								{"id": "U_kgDOCbOMzw", "login": "testuser"}
+							]
+						}`,
+					}, nil
+				},
+				RunXFn: func(ctx context.Context, command string, args ...string) (string, error) {
+					t.Logf("RunX command: %s, args: %v", command, args)
+					require.Contains(t, args, "--add-assignee")
+					require.Contains(t, args, "testuser2")
+					require.NotContains(t, args, "testuser")
+					return "", nil
+				},
+				Logger: slog.New(slog.DiscardHandler),
+			}
+
+			prURL, isNewPR, err := CreatePRIfNotExist(context.Background(), xr, PROptions{
+				Title: "Test PR",
+				Body:  "This is a test PR",
+				Assignees: []string{"testuser2"},
+			})
+			require.NoError(t, err)
+			require.Equal(t, false, isNewPR)
+			require.Equal(t, "https://github.com/jcchavezs/gh-iterator/pull/21", prURL)
+		})
+	})
 }
 
 func TestIsRepositoryArchived(t *testing.T) {


### PR DESCRIPTION
This pull request enhances the pull request creation and editing workflow by adding support for specifying assignees when creating or updating a pull request. It introduces a new field in the `PROptions` struct, updates the logic to handle assignees both for new and existing pull requests, and adds comprehensive tests to ensure correct behavior.

Enhancements to pull request options and workflow:

* Added an `Assignees` field to the `PROptions` struct, allowing users to specify assignees when creating or updating a pull request.
* Updated the `CreatePRIfNotExist` function to:
  - Pass the assignees to the `gh pr create` command when creating a new PR.
  - Add only new assignees to existing PRs using the `gh pr edit --add-assignee` command, avoiding duplicates. [[1]](diffhunk://#diff-9ba908d887f1d686a0a524b3cb3ff334b402122a9e5c4b8ba150a5fa6b5ff16bR272-R294) [[2]](diffhunk://#diff-9ba908d887f1d686a0a524b3cb3ff334b402122a9e5c4b8ba150a5fa6b5ff16bR217-R232)
  - Parse the assignees from the existing PR response to support the above logic.
* Improved logging to clarify PR creation and updating actions.

Testing improvements:

* Added tests for the new assignee functionality, covering both new and existing pull request scenarios to ensure correct command invocation and behavior.

Documentation and code clarity:

* Added and improved comments for new types and functions, such as `PushOption`, `PROptions`, and `IsRepositoryArchived`, to enhance code readability. [[1]](diffhunk://#diff-9ba908d887f1d686a0a524b3cb3ff334b402122a9e5c4b8ba150a5fa6b5ff16bR128) [[2]](diffhunk://#diff-9ba908d887f1d686a0a524b3cb3ff334b402122a9e5c4b8ba150a5fa6b5ff16bR351)