### PR TITLE
Adds read file

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -367,3 +367,25 @@ func IsRepositoryArchived(ctx context.Context, repoName string, xr iteratorexec.
 
 	return false, fmt.Errorf("checking if repository is archived: %w", err)
 }
+
+func ReadFile(ctx context.Context, xr iteratorexec.Execer, repo string, filePath string) ([]byte, error) {
+	out, err := xr.RunX(ctx, "gh", "api",
+		fmt.Sprintf("/repos/%s/contents/%s", repo, filePath),
+		"-H", "Accept: application/vnd.github.raw+json",
+	)
+
+	if err == nil {
+		return []byte(out), nil
+	}
+
+	var errResponse ghErrResponse
+	if err := json.Unmarshal([]byte(out), &errResponse); err == nil {
+		if errResponse.Status == "404" {
+			return nil, fmt.Errorf("reading file %q: %w", filePath, os.ErrNotExist)
+		}
+
+		return nil, fmt.Errorf("reading file %q: %s", filePath, errResponse.Message)
+	}
+
+	return nil, fmt.Errorf("reading file %q: %w", filePath, err)
+}

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -305,6 +305,64 @@ func TestIsRepositoryArchived(t *testing.T) {
 	})
 }
 
+func TestReadFile(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		x := mock.Execer{
+			RunXFn: func(ctx context.Context, command string, args ...string) (string, error) {
+				require.Equal(t, "gh", command)
+				require.Equal(t, []string{"api", "/repos/owner/repo/contents/path/to/file.txt", "-H", "Accept: application/vnd.github.raw+json"}, args)
+				return "file contents", nil
+			},
+			Logger: slog.New(slog.DiscardHandler),
+		}
+
+		content, err := ReadFile(context.Background(), x, "owner/repo", "path/to/file.txt")
+		require.NoError(t, err)
+		require.Equal(t, []byte("file contents"), content)
+	})
+
+	t.Run("file not found", func(t *testing.T) {
+		x := mock.Execer{
+			RunXFn: func(ctx context.Context, command string, args ...string) (string, error) {
+				return `{"message":"Not Found","status":"404"}`, errors.New("exit status 1")
+			},
+			Logger: slog.New(slog.DiscardHandler),
+		}
+
+		content, err := ReadFile(context.Background(), x, "owner/repo", "missing.txt")
+		require.ErrorIs(t, err, os.ErrNotExist)
+		require.Nil(t, content)
+	})
+
+	t.Run("api error with message", func(t *testing.T) {
+		x := mock.Execer{
+			RunXFn: func(ctx context.Context, command string, args ...string) (string, error) {
+				return `{"message":"Bad credentials","status":"401"}`, errors.New("exit status 1")
+			},
+			Logger: slog.New(slog.DiscardHandler),
+		}
+
+		content, err := ReadFile(context.Background(), x, "owner/repo", "file.txt")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Bad credentials")
+		require.Nil(t, content)
+	})
+
+	t.Run("unexpected error", func(t *testing.T) {
+		x := mock.Execer{
+			RunXFn: func(ctx context.Context, command string, args ...string) (string, error) {
+				return "", errors.New("network failure")
+			},
+			Logger: slog.New(slog.DiscardHandler),
+		}
+
+		content, err := ReadFile(context.Background(), x, "owner/repo", "file.txt")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "network failure")
+		require.Nil(t, content)
+	})
+}
+
 func TestForkAndAddRemote(t *testing.T) {
 	t.Run("successful fork and add remote", func(t *testing.T) {
 		x := mock.Execer{

--- a/iterator.go
+++ b/iterator.go
@@ -251,7 +251,7 @@ func checkCloneability(ctx context.Context, repoPages [][]Repository, filterIn f
 			repoURL = repo.URL
 		}
 
-		out, err := xr.RunX(ctx, "git", "ls-remote", "--exit-code", repoURL)
+		_, err := xr.RunX(ctx, "git", "ls-remote", "--exit-code", repoURL)
 		if err == nil {
 			if len(errs) > 0 {
 				logger.Debug("Cloneability check passed after previous failures", "error", errors.Join(errs...))
@@ -259,7 +259,6 @@ func checkCloneability(ctx context.Context, repoPages [][]Repository, filterIn f
 
 			return nil
 		}
-		fmt.Println(out)
 
 		errs = append(errs, fmt.Errorf("checking repository %q cloneability: %w", repo.Name, err))
 	}

--- a/iterator.go
+++ b/iterator.go
@@ -251,7 +251,7 @@ func checkCloneability(ctx context.Context, repoPages [][]Repository, filterIn f
 			repoURL = repo.URL
 		}
 
-		_, err := xr.RunX(ctx, "git", "ls-remote", "--exit-code", repoURL)
+		out, err := xr.RunX(ctx, "git", "ls-remote", "--exit-code", repoURL)
 		if err == nil {
 			if len(errs) > 0 {
 				logger.Debug("Cloneability check passed after previous failures", "error", errors.Join(errs...))
@@ -259,6 +259,7 @@ func checkCloneability(ctx context.Context, repoPages [][]Repository, filterIn f
 
 			return nil
 		}
+		fmt.Println(out)
 
 		errs = append(errs, fmt.Errorf("checking repository %q cloneability: %w", repo.Name, err))
 	}


### PR DESCRIPTION
This pull request introduces a new `ReadFile` function to the `github` package, enabling the reading of file contents from a GitHub repository via the GitHub API. Comprehensive tests are also added to ensure the function handles various scenarios, such as successful reads, file-not-found errors, API errors, and unexpected failures.

**New functionality:**

* Added the `ReadFile` function in `github/github.go` to fetch file contents from a GitHub repository using the GitHub API, with robust error handling for common API responses.

**Testing improvements:**

* Introduced the `TestReadFile` test suite in `github/github_test.go` to cover successful reads, missing files, API errors, and unexpected errors, ensuring the reliability of the new `ReadFile` function.