### PR TITLE
feat: adds CallIs function to write better tests when using xr mocks

### DIFF
--- a/exec/mock/call.go
+++ b/exec/mock/call.go
@@ -1,0 +1,57 @@
+package mock
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// CallIs is a helper function for tests that checks if the given command and arguments match the expected values.
+// It returns true if the command and arguments match, and false otherwise.
+// The first element of expected is the expected command, and the remaining elements are the expected arguments.
+// If an expected argument is CallAny, it will match any value for that argument position.
+func CallIs(t *testing.T, cmd string, args []string, expected ...any) bool {
+	t.Helper()
+
+	if len(expected) > len(args)+1 {
+		return false
+	}
+
+	if cmd != expected[0] {
+		return false
+	}
+
+	for i, xArg := range expected[1:] {
+		switch txArg := xArg.(type) {
+		case CallArg:
+			if txArg == nil {
+				continue
+			}
+
+			if !txArg(args[i]) {
+				t.Log("argument mismatch at position", i, "expected condition to be true, actual:", args[i])
+				return false
+			}
+		case string:
+			if txArg != args[i] {
+				t.Log("argument mismatch at position", i, "expected:", txArg, "actual:", args[i])
+				return false
+			}
+		default:
+			require.Fail(t, "expected argument must be a string or condition")
+		}
+	}
+
+	return true
+}
+
+type CallArg func(string) bool
+
+var (
+	// CallAny is a sentinel value used in tests to indicate that any value is acceptable for a given argument position.
+	CallAny CallArg = nil
+
+	// ErrUnexpectedCall is an error returned by the mock Execer when an unexpected command is called.
+	ErrUnexpectedCall = errors.New("unexpected call")
+)

--- a/exec/mock/call_test.go
+++ b/exec/mock/call_test.go
@@ -1,0 +1,46 @@
+package mock
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCallIs_CommandMatch(t *testing.T) {
+	require.True(t, CallIs(t, "git", []string{}, "git"))
+}
+
+func TestCallIs_CommandMismatch(t *testing.T) {
+	require.False(t, CallIs(t, "git", []string{}, "gh"))
+}
+
+func TestCallIs_TooManyExpected(t *testing.T) {
+	require.False(t, CallIs(t, "git", []string{"status"}, "git", "status", "extra"))
+}
+
+func TestCallIs_StringArgMatch(t *testing.T) {
+	require.True(t, CallIs(t, "git", []string{"clone", "repo"}, "git", "clone", "repo"))
+}
+
+func TestCallIs_StringArgMismatch(t *testing.T) {
+	require.False(t, CallIs(t, "git", []string{"clone", "repo"}, "git", "clone", "other"))
+}
+
+func TestCallIs_CallAnyArg(t *testing.T) {
+	require.True(t, CallIs(t, "git", []string{"clone", "any-repo"}, "git", "clone", CallAny))
+}
+
+func TestCallIs_CallArgMatch(t *testing.T) {
+	startsWithHTTPS := CallArg(func(s string) bool { return strings.HasPrefix(s, "https://") })
+	require.True(t, CallIs(t, "git", []string{"clone", "https://github.com/org/repo"}, "git", "clone", startsWithHTTPS))
+}
+
+func TestCallIs_CallArgMismatch(t *testing.T) {
+	startsWithHTTPS := CallArg(func(s string) bool { return strings.HasPrefix(s, "https://") })
+	require.False(t, CallIs(t, "git", []string{"clone", "git@github.com:org/repo"}, "git", "clone", startsWithHTTPS))
+}
+
+func TestCallIs_FewerExpectedThanActualArgs(t *testing.T) {
+	require.True(t, CallIs(t, "git", []string{"clone", "repo", "--depth=1"}, "git", "clone"))
+}

--- a/exec/mock/mock.go
+++ b/exec/mock/mock.go
@@ -17,9 +17,11 @@ type Execer struct {
 	RunWithStdinXFn func(ctx context.Context, stdin io.Reader, command string, args ...string) (string, error)
 	Logger          *slog.Logger
 
-	WithEnvFn       func(kv ...string) iteratorexec.Execer
-	WithLogFieldsFn func(fields ...any) iteratorexec.Execer
-	SubFn           func(subpath string) (iteratorexec.Execer, error)
+	// 'self' allows you to return the same mock Execer when calling WithEnv, WithLogFields or Sub
+	// This is useful when you want to chain calls and keep the same mock behavior.
+	WithEnvFn       func(self Execer, kv ...string) iteratorexec.Execer
+	WithLogFieldsFn func(self Execer, fields ...any) iteratorexec.Execer
+	SubFn           func(self Execer, subpath string) (iteratorexec.Execer, error)
 	GenerateFSFn    func() afero.Fs
 }
 
@@ -50,15 +52,15 @@ func (x Execer) Log(ctx context.Context, level slog.Level, msg string, fields ..
 func (x Execer) DebugShell(context.Context) {}
 
 func (x Execer) WithEnv(kv ...string) iteratorexec.Execer {
-	return x.WithEnvFn(kv...)
+	return x.WithEnvFn(x, kv...)
 }
 
 func (x Execer) WithLogFields(fields ...any) iteratorexec.Execer {
-	return x.WithLogFieldsFn(fields...)
+	return x.WithLogFieldsFn(x, fields...)
 }
 
 func (x Execer) Sub(subpath string) (iteratorexec.Execer, error) {
-	return x.SubFn(subpath)
+	return x.SubFn(x, subpath)
 }
 
 func (x Execer) GenerateFS() afero.Fs {

--- a/exec/mock/mock_test.go
+++ b/exec/mock/mock_test.go
@@ -1,0 +1,175 @@
+package mock
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	iteratorexec "github.com/jcchavezs/gh-iterator/exec"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecer_Run(t *testing.T) {
+	expected := iteratorexec.Result{Stdout: "output", ExitCode: 0}
+	x := Execer{
+		RunFn: func(_ context.Context, command string, args ...string) (iteratorexec.Result, error) {
+			require.True(t, CallIs(t, command, args, "git", "status"))
+			return expected, nil
+		},
+	}
+
+	result, err := x.Run(context.Background(), "git", "status")
+	require.NoError(t, err)
+	require.Equal(t, expected, result)
+}
+
+func TestExecer_RunX(t *testing.T) {
+	x := Execer{
+		RunXFn: func(_ context.Context, command string, args ...string) (string, error) {
+			require.True(t, CallIs(t, command, args, "git", "rev-parse", "HEAD"))
+			return "abc123", nil
+		},
+	}
+
+	out, err := x.RunX(context.Background(), "git", "rev-parse", "HEAD")
+	require.NoError(t, err)
+	require.Equal(t, "abc123", out)
+}
+
+func TestExecer_RunWithStdin(t *testing.T) {
+	expected := iteratorexec.Result{Stdout: "ok", ExitCode: 0}
+	stdin := strings.NewReader("input")
+	x := Execer{
+		RunWithStdinFn: func(_ context.Context, r io.Reader, command string, args ...string) (iteratorexec.Result, error) {
+			require.Equal(t, stdin, r)
+			require.True(t, CallIs(t, command, args, "cat"))
+			return expected, nil
+		},
+	}
+
+	result, err := x.RunWithStdin(context.Background(), stdin, "cat")
+	require.NoError(t, err)
+	require.Equal(t, expected, result)
+}
+
+func TestExecer_RunWithStdinX(t *testing.T) {
+	stdin := strings.NewReader("input")
+	x := Execer{
+		RunWithStdinXFn: func(_ context.Context, r io.Reader, command string, args ...string) (string, error) {
+			require.Equal(t, stdin, r)
+			require.True(t, CallIs(t, command, args, "cat"))
+			return "input", nil
+		},
+	}
+
+	out, err := x.RunWithStdinX(context.Background(), stdin, "cat")
+	require.NoError(t, err)
+	require.Equal(t, "input", out)
+}
+
+func TestExecer_Log_WithLogger(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	x := Execer{Logger: logger}
+
+	x.Log(context.Background(), slog.LevelInfo, "hello", "key", "val")
+
+	require.Contains(t, buf.String(), "hello")
+}
+
+func TestExecer_Log_WithoutLogger(t *testing.T) {
+	// Should not panic when Logger is nil
+	x := Execer{}
+	require.NotPanics(t, func() {
+		x.Log(context.Background(), slog.LevelInfo, "hello")
+	})
+}
+
+func TestExecer_DebugShell(t *testing.T) {
+	x := Execer{}
+	// Should be a no-op and not panic
+	require.NotPanics(t, func() {
+		x.DebugShell(context.Background())
+	})
+}
+
+func TestExecer_WithEnv(t *testing.T) {
+	// We need to return a new Execer from WithEnvFn to simulate the behavior of creating a new instance with the environment variables set.
+	// We can't return x directly because that will fail the test as deep equality will not hold due to the function pointers even if they are copies
+	child := Execer{}
+	x := Execer{
+		WithEnvFn: func(self Execer, kv ...string) iteratorexec.Execer {
+			require.Equal(t, []string{"KEY", "VAL"}, kv)
+			return child
+		},
+	}
+
+	result := x.WithEnv("KEY", "VAL")
+	require.Equal(t, child, result)
+}
+
+func TestExecer_WithLogFields(t *testing.T) {
+	child := Execer{}
+	x := Execer{
+		WithLogFieldsFn: func(s Execer, fields ...any) iteratorexec.Execer {
+			require.Equal(t, []any{"key", "val"}, fields)
+			return child
+		},
+	}
+
+	result := x.WithLogFields("key", "val")
+	require.Equal(t, child, result)
+}
+
+func TestExecer_Sub(t *testing.T) {
+	child := Execer{}
+	x := Execer{
+		SubFn: func(s Execer, subpath string) (iteratorexec.Execer, error) {
+			require.Equal(t, "subdir", subpath)
+			return child, nil
+		},
+	}
+
+	result, err := x.Sub("subdir")
+	require.NoError(t, err)
+	require.Equal(t, child, result)
+}
+
+func TestExecer_GenerateFS(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	x := Execer{
+		GenerateFSFn: func() afero.Fs {
+			return fs
+		},
+	}
+
+	result := x.GenerateFS()
+	require.Equal(t, fs, result)
+}
+
+func ExampleExecer() {
+	xr := Execer{
+		RunFn: func(_ context.Context, command string, args ...string) (iteratorexec.Result, error) {
+			fmt.Println("Run called with:", command, args)
+			return iteratorexec.Result{ExitCode: 0}, nil
+		},
+		WithEnvFn: func(self Execer, kv ...string) iteratorexec.Execer {
+			fmt.Println("WithEnv called with:", kv)
+			return self
+		},
+	}
+
+	_, err := xr.WithEnv("USER", "tito").Run(context.Background(), "echo", "hello")
+	if err != nil {
+		fmt.Println("Error:", err)
+	}
+
+	// Output:
+	// WithEnv called with: [USER tito]
+	// Run called with: echo [hello]
+}

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -186,12 +186,11 @@ func TestCreatePRIfNotExist(t *testing.T) {
 			},
 			RunXFn: func(ctx context.Context, command string, args ...string) (string, error) {
 				t.Logf("RunX command: %s, args: %v", command, args)
-				require.Len(t, args, 3)
-				require.Equal(t, "gh", command)
-				require.Equal(t, "pr", args[0])
-				require.Equal(t, "create", args[1])
-				require.Equal(t, "--fill", args[2])
-				return "https://github.com/jcchavezs/gh-iterator/pull/22", nil
+				if mock.CallIs(t, command, args, "gh", "pr", "create", "--fill") {
+					return "https://github.com/jcchavezs/gh-iterator/pull/22", nil
+				}
+
+				return "", mock.ErrUnexpectedCall
 			},
 			Logger: slog.New(slog.DiscardHandler),
 		}
@@ -212,16 +211,18 @@ func TestCreatePRIfNotExist(t *testing.T) {
 				},
 				RunXFn: func(ctx context.Context, command string, args ...string) (string, error) {
 					t.Logf("RunX command: %s, args: %v", command, args)
-					require.Contains(t, args, "--assignee")
-					require.Contains(t, args, "testuser")
-					return "", nil
+					if mock.CallIs(t, command, args, "gh", "pr", "create", "--body-file", mock.CallAny, "--title", mock.CallAny, "--assignee", "testuser") {
+						return "", nil
+					}
+
+					return "", mock.ErrUnexpectedCall
 				},
 				Logger: slog.New(slog.DiscardHandler),
 			}
 
 			_, _, err := CreatePRIfNotExist(context.Background(), xr, PROptions{
-				Title: "Test PR",
-				Body:  "This is a test PR",
+				Title:     "Test PR",
+				Body:      "This is a test PR",
 				Assignees: []string{"testuser"},
 			})
 			require.NoError(t, err)
@@ -243,17 +244,18 @@ func TestCreatePRIfNotExist(t *testing.T) {
 				},
 				RunXFn: func(ctx context.Context, command string, args ...string) (string, error) {
 					t.Logf("RunX command: %s, args: %v", command, args)
-					require.Contains(t, args, "--add-assignee")
-					require.Contains(t, args, "testuser2")
-					require.NotContains(t, args, "testuser")
-					return "", nil
+					if mock.CallIs(t, command, args, "gh", "pr", "edit", mock.CallAny, "--body-file", mock.CallAny, "--title", "Test PR", "--add-assignee", "testuser2") {
+						return "", nil
+					}
+
+					return "", mock.ErrUnexpectedCall
 				},
 				Logger: slog.New(slog.DiscardHandler),
 			}
 
 			prURL, isNewPR, err := CreatePRIfNotExist(context.Background(), xr, PROptions{
-				Title: "Test PR",
-				Body:  "This is a test PR",
+				Title:     "Test PR",
+				Body:      "This is a test PR",
 				Assignees: []string{"testuser2"},
 			})
 			require.NoError(t, err)
@@ -309,25 +311,13 @@ func TestForkAndAddRemote(t *testing.T) {
 	t.Run("successful fork and add remote", func(t *testing.T) {
 		x := mock.Execer{
 			RunXFn: func(ctx context.Context, command string, args ...string) (string, error) {
-				if command == "gh" && len(args) >= 1 && args[0] == "api" {
-					// Mock the getCurrentUser call
-					require.Len(t, args, 4)
-					require.Equal(t, "user", args[1])
-					require.Equal(t, "--jq", args[2])
-					require.Equal(t, ".login", args[3])
+				if mock.CallIs(t, command, args, "gh", "api", "user", "--jq", ".login") {
 					return "testuser", nil
 				}
-
-				if command == "gh" && len(args) >= 1 && args[0] == "repo" {
-					// Mock the fork call
-					require.Len(t, args, 5)
-					require.Equal(t, "fork", args[1])
-					require.Equal(t, "--remote", args[2])
-					require.Equal(t, "--remote-name", args[3])
-					require.Equal(t, "upstream", args[4])
+				if mock.CallIs(t, command, args, "gh", "repo", "fork", "--remote", "--remote-name", "upstream") {
 					return "", nil
 				}
-				return "", errors.New("unexpected command")
+				return "", mock.ErrUnexpectedCall
 			},
 			Logger: slog.New(slog.DiscardHandler),
 		}
@@ -336,7 +326,6 @@ func TestForkAndAddRemote(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, headRefFn)
 
-		// Test the returned function
 		headRef := headRefFn("feature-branch")
 		require.Equal(t, "testuser:feature-branch", headRef)
 
@@ -347,10 +336,10 @@ func TestForkAndAddRemote(t *testing.T) {
 	t.Run("error getting current user", func(t *testing.T) {
 		x := mock.Execer{
 			RunXFn: func(ctx context.Context, command string, args ...string) (string, error) {
-				if command == "gh" && len(args) >= 1 && args[0] == "api" {
+				if mock.CallIs(t, command, args, "gh", "api") {
 					return "", errors.New("failed to get user")
 				}
-				return "", errors.New("unexpected command")
+				return "", mock.ErrUnexpectedCall
 			},
 			Logger: slog.New(slog.DiscardHandler),
 		}
@@ -364,15 +353,13 @@ func TestForkAndAddRemote(t *testing.T) {
 	t.Run("error forking repository", func(t *testing.T) {
 		x := mock.Execer{
 			RunXFn: func(ctx context.Context, command string, args ...string) (string, error) {
-				if command == "gh" && len(args) >= 1 && args[0] == "api" {
-					// Mock the getCurrentUser call
+				if mock.CallIs(t, command, args, "gh", "api") {
 					return "testuser", nil
 				}
-				if command == "gh" && len(args) >= 1 && args[0] == "repo" {
-					// Mock the fork call
+				if mock.CallIs(t, command, args, "gh", "repo", "fork") {
 					return "", errors.New("failed to fork repository")
 				}
-				return "", errors.New("unexpected command")
+				return "", mock.ErrUnexpectedCall
 			},
 			Logger: slog.New(slog.DiscardHandler),
 		}


### PR DESCRIPTION
This pull request introduces a new helper for mocking command-line executions in tests, and refactors several tests to use this new utility. The main goal is to make test assertions about command invocations more flexible and easier to read, while also improving error reporting for unexpected calls.
