### PR TITLE
feat: adds CallIs function to write better tests when using xr mocks

### DIFF
--- a/exec/mock/call.go
+++ b/exec/mock/call.go
@@ -1,0 +1,57 @@
+package mock
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// CallIs is a helper function for tests that checks if the given command and arguments match the expected values.
+// It returns true if the command and arguments match, and false otherwise.
+// The first element of expected is the expected command, and the remaining elements are the expected arguments.
+// If an expected argument is CallAny, it will match any value for that argument position.
+func CallIs(t *testing.T, cmd string, args []string, expected ...any) bool {
+	t.Helper()
+
+	if len(expected) > len(args)+1 {
+		return false
+	}
+
+	if cmd != expected[0] {
+		return false
+	}
+
+	for i, xArg := range expected[1:] {
+		switch txArg := xArg.(type) {
+		case CallArg:
+			if txArg == nil {
+				continue
+			}
+
+			if !txArg(args[i]) {
+				t.Log("argument mismatch at position", i, "expected condition to be true, actual:", args[i])
+				return false
+			}
+		case string:
+			if txArg != args[i] {
+				t.Log("argument mismatch at position", i, "expected:", txArg, "actual:", args[i])
+				return false
+			}
+		default:
+			require.Fail(t, "expected argument must be a string or condition")
+		}
+	}
+
+	return true
+}
+
+type CallArg func(string) bool
+
+var (
+	// CallAny is a sentinel value used in tests to indicate that any value is acceptable for a given argument position.
+	CallAny CallArg = nil
+
+	// ErrUnexpectedCall is an error returned by the mock Execer when an unexpected command is called.
+	ErrUnexpectedCall = errors.New("unexpected call")
+)

--- a/exec/mock/call_test.go
+++ b/exec/mock/call_test.go
@@ -1,0 +1,46 @@
+package mock
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCallIs_CommandMatch(t *testing.T) {
+	require.True(t, CallIs(t, "git", []string{}, "git"))
+}
+
+func TestCallIs_CommandMismatch(t *testing.T) {
+	require.False(t, CallIs(t, "git", []string{}, "gh"))
+}
+
+func TestCallIs_TooManyExpected(t *testing.T) {
+	require.False(t, CallIs(t, "git", []string{"status"}, "git", "status", "extra"))
+}
+
+func TestCallIs_StringArgMatch(t *testing.T) {
+	require.True(t, CallIs(t, "git", []string{"clone", "repo"}, "git", "clone", "repo"))
+}
+
+func TestCallIs_StringArgMismatch(t *testing.T) {
+	require.False(t, CallIs(t, "git", []string{"clone", "repo"}, "git", "clone", "other"))
+}
+
+func TestCallIs_CallAnyArg(t *testing.T) {
+	require.True(t, CallIs(t, "git", []string{"clone", "any-repo"}, "git", "clone", CallAny))
+}
+
+func TestCallIs_CallArgMatch(t *testing.T) {
+	startsWithHTTPS := CallArg(func(s string) bool { return strings.HasPrefix(s, "https://") })
+	require.True(t, CallIs(t, "git", []string{"clone", "https://github.com/org/repo"}, "git", "clone", startsWithHTTPS))
+}
+
+func TestCallIs_CallArgMismatch(t *testing.T) {
+	startsWithHTTPS := CallArg(func(s string) bool { return strings.HasPrefix(s, "https://") })
+	require.False(t, CallIs(t, "git", []string{"clone", "git@github.com:org/repo"}, "git", "clone", startsWithHTTPS))
+}
+
+func TestCallIs_FewerExpectedThanActualArgs(t *testing.T) {
+	require.True(t, CallIs(t, "git", []string{"clone", "repo", "--depth=1"}, "git", "clone"))
+}

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -186,12 +186,11 @@ func TestCreatePRIfNotExist(t *testing.T) {
 			},
 			RunXFn: func(ctx context.Context, command string, args ...string) (string, error) {
 				t.Logf("RunX command: %s, args: %v", command, args)
-				require.Len(t, args, 3)
-				require.Equal(t, "gh", command)
-				require.Equal(t, "pr", args[0])
-				require.Equal(t, "create", args[1])
-				require.Equal(t, "--fill", args[2])
-				return "https://github.com/jcchavezs/gh-iterator/pull/22", nil
+				if mock.CallIs(t, command, args, "gh", "pr", "create", "--fill") {
+					return "https://github.com/jcchavezs/gh-iterator/pull/22", nil
+				}
+
+				return "", mock.ErrUnexpectedCall
 			},
 			Logger: slog.New(slog.DiscardHandler),
 		}
@@ -212,16 +211,18 @@ func TestCreatePRIfNotExist(t *testing.T) {
 				},
 				RunXFn: func(ctx context.Context, command string, args ...string) (string, error) {
 					t.Logf("RunX command: %s, args: %v", command, args)
-					require.Contains(t, args, "--assignee")
-					require.Contains(t, args, "testuser")
-					return "", nil
+					if mock.CallIs(t, command, args, "gh", "pr", "create", "--body-file", mock.CallAny, "--title", mock.CallAny, "--assignee", "testuser") {
+						return "", nil
+					}
+
+					return "", mock.ErrUnexpectedCall
 				},
 				Logger: slog.New(slog.DiscardHandler),
 			}
 
 			_, _, err := CreatePRIfNotExist(context.Background(), xr, PROptions{
-				Title: "Test PR",
-				Body:  "This is a test PR",
+				Title:     "Test PR",
+				Body:      "This is a test PR",
 				Assignees: []string{"testuser"},
 			})
 			require.NoError(t, err)
@@ -243,17 +244,18 @@ func TestCreatePRIfNotExist(t *testing.T) {
 				},
 				RunXFn: func(ctx context.Context, command string, args ...string) (string, error) {
 					t.Logf("RunX command: %s, args: %v", command, args)
-					require.Contains(t, args, "--add-assignee")
-					require.Contains(t, args, "testuser2")
-					require.NotContains(t, args, "testuser")
-					return "", nil
+					if mock.CallIs(t, command, args, "gh", "pr", "edit", mock.CallAny, "--body-file", mock.CallAny, "--title", "Test PR", "--add-assignee", "testuser2") {
+						return "", nil
+					}
+
+					return "", mock.ErrUnexpectedCall
 				},
 				Logger: slog.New(slog.DiscardHandler),
 			}
 
 			prURL, isNewPR, err := CreatePRIfNotExist(context.Background(), xr, PROptions{
-				Title: "Test PR",
-				Body:  "This is a test PR",
+				Title:     "Test PR",
+				Body:      "This is a test PR",
 				Assignees: []string{"testuser2"},
 			})
 			require.NoError(t, err)
@@ -367,25 +369,13 @@ func TestForkAndAddRemote(t *testing.T) {
 	t.Run("successful fork and add remote", func(t *testing.T) {
 		x := mock.Execer{
 			RunXFn: func(ctx context.Context, command string, args ...string) (string, error) {
-				if command == "gh" && len(args) >= 1 && args[0] == "api" {
-					// Mock the getCurrentUser call
-					require.Len(t, args, 4)
-					require.Equal(t, "user", args[1])
-					require.Equal(t, "--jq", args[2])
-					require.Equal(t, ".login", args[3])
+				if mock.CallIs(t, command, args, "gh", "api", "user", "--jq", ".login") {
 					return "testuser", nil
 				}
-
-				if command == "gh" && len(args) >= 1 && args[0] == "repo" {
-					// Mock the fork call
-					require.Len(t, args, 5)
-					require.Equal(t, "fork", args[1])
-					require.Equal(t, "--remote", args[2])
-					require.Equal(t, "--remote-name", args[3])
-					require.Equal(t, "upstream", args[4])
+				if mock.CallIs(t, command, args, "gh", "repo", "fork", "--remote", "--remote-name", "upstream") {
 					return "", nil
 				}
-				return "", errors.New("unexpected command")
+				return "", mock.ErrUnexpectedCall
 			},
 			Logger: slog.New(slog.DiscardHandler),
 		}
@@ -394,7 +384,6 @@ func TestForkAndAddRemote(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, headRefFn)
 
-		// Test the returned function
 		headRef := headRefFn("feature-branch")
 		require.Equal(t, "testuser:feature-branch", headRef)
 
@@ -405,10 +394,10 @@ func TestForkAndAddRemote(t *testing.T) {
 	t.Run("error getting current user", func(t *testing.T) {
 		x := mock.Execer{
 			RunXFn: func(ctx context.Context, command string, args ...string) (string, error) {
-				if command == "gh" && len(args) >= 1 && args[0] == "api" {
+				if mock.CallIs(t, command, args, "gh", "api") {
 					return "", errors.New("failed to get user")
 				}
-				return "", errors.New("unexpected command")
+				return "", mock.ErrUnexpectedCall
 			},
 			Logger: slog.New(slog.DiscardHandler),
 		}
@@ -422,15 +411,13 @@ func TestForkAndAddRemote(t *testing.T) {
 	t.Run("error forking repository", func(t *testing.T) {
 		x := mock.Execer{
 			RunXFn: func(ctx context.Context, command string, args ...string) (string, error) {
-				if command == "gh" && len(args) >= 1 && args[0] == "api" {
-					// Mock the getCurrentUser call
+				if mock.CallIs(t, command, args, "gh", "api") {
 					return "testuser", nil
 				}
-				if command == "gh" && len(args) >= 1 && args[0] == "repo" {
-					// Mock the fork call
+				if mock.CallIs(t, command, args, "gh", "repo", "fork") {
 					return "", errors.New("failed to fork repository")
 				}
-				return "", errors.New("unexpected command")
+				return "", mock.ErrUnexpectedCall
 			},
 			Logger: slog.New(slog.DiscardHandler),
 		}


### PR DESCRIPTION
This pull request introduces a new helper for mocking command-line executions in tests, and refactors several tests to use this new utility. The main goal is to make test assertions about command invocations more flexible and easier to read, while also improving error reporting for unexpected calls.